### PR TITLE
[FDORA-21] feat: 장바구니 추가 API 구현

### DIFF
--- a/src/main/java/com/farmdora/farmdorabuyer/basket/controller/BasketController.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/controller/BasketController.java
@@ -1,0 +1,29 @@
+package com.farmdora.farmdorabuyer.basket.controller;
+
+import static com.farmdora.farmdorabuyer.common.response.SuccessMessage.ADD_BASKET_SUCCESS;
+
+import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
+import com.farmdora.farmdorabuyer.basket.service.BasketService;
+import com.farmdora.farmdorabuyer.common.response.HttpResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/basket")
+@RequiredArgsConstructor
+public class BasketController {
+
+    private final BasketService basketService;
+
+    @PostMapping
+    public ResponseEntity<?> addBasket(BasketRequestDto basketRequest) {
+        Integer userId = 1;
+        basketService.addBasket(userId, basketRequest);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, ADD_BASKET_SUCCESS.getMessage(), null));
+    }
+}

--- a/src/main/java/com/farmdora/farmdorabuyer/basket/dto/BasketRequestDto.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/dto/BasketRequestDto.java
@@ -1,0 +1,14 @@
+package com.farmdora.farmdorabuyer.basket.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class BasketRequestDto {
+    private Integer optionId;
+    private Integer quantity;
+}

--- a/src/main/java/com/farmdora/farmdorabuyer/basket/exception/BasketOverLimitException.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/exception/BasketOverLimitException.java
@@ -1,0 +1,11 @@
+package com.farmdora.farmdorabuyer.basket.exception;
+
+import com.farmdora.farmdorabuyer.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class BasketOverLimitException extends BaseException {
+
+    public BasketOverLimitException(String message, HttpStatus status) {
+        super(message, status);
+    }
+}

--- a/src/main/java/com/farmdora/farmdorabuyer/basket/repository/BasketRepository.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/repository/BasketRepository.java
@@ -1,8 +1,11 @@
 package com.farmdora.farmdorabuyer.basket.repository;
 
 import com.farmdora.farmdorabuyer.entity.Basket;
+import com.farmdora.farmdorabuyer.entity.Option;
+import com.farmdora.farmdorabuyer.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BasketRepository extends JpaRepository<Basket, Integer> {
-
+    Optional<Basket> findByUserAndOption(User user, Option option);
 }

--- a/src/main/java/com/farmdora/farmdorabuyer/basket/repository/BasketRepository.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/repository/BasketRepository.java
@@ -1,0 +1,8 @@
+package com.farmdora.farmdorabuyer.basket.repository;
+
+import com.farmdora.farmdorabuyer.entity.Basket;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BasketRepository extends JpaRepository<Basket, Integer> {
+
+}

--- a/src/main/java/com/farmdora/farmdorabuyer/basket/repository/BasketRepository.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/repository/BasketRepository.java
@@ -8,4 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BasketRepository extends JpaRepository<Basket, Integer> {
     Optional<Basket> findByUserAndOption(User user, Option option);
+    Long countByUser(User user);
 }

--- a/src/main/java/com/farmdora/farmdorabuyer/basket/service/BasketService.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/service/BasketService.java
@@ -1,6 +1,7 @@
 package com.farmdora.farmdorabuyer.basket.service;
 
 import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
+import com.farmdora.farmdorabuyer.basket.exception.BasketOverLimitException;
 import com.farmdora.farmdorabuyer.basket.repository.BasketRepository;
 import com.farmdora.farmdorabuyer.common.exception.ResourceAlreadyExistsException;
 import com.farmdora.farmdorabuyer.common.exception.ResourceNotFoundException;
@@ -11,6 +12,7 @@ import com.farmdora.farmdorabuyer.orders.repository.OptionRepository;
 import com.farmdora.farmdorabuyer.orders.repository.UserRepository;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +24,8 @@ public class BasketService {
     private final UserRepository userRepository;
     private final OptionRepository optionRepository;
 
+    private static final int BASKET_LIMIT = 16;
+
     public void addBasket(Integer userId, BasketRequestDto basketAddRequest) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("User", userId));
@@ -29,10 +33,8 @@ public class BasketService {
         Option option = optionRepository.findById(basketAddRequest.getOptionId())
                 .orElseThrow(() -> new ResourceNotFoundException("Option", basketAddRequest.getOptionId()));
 
-        Optional<Basket> existsBasket = basketRepository.findByUserAndOption(user, option);
-        if (existsBasket.isPresent()) {
-            throw new ResourceAlreadyExistsException("Basket", existsBasket.get().getId());
-        }
+        checkBasketAlreadyExists(user, option);
+        checkBasketLimit(user);
 
         Basket basket = Basket.builder()
                 .user(user)
@@ -40,5 +42,19 @@ public class BasketService {
                 .quantity(basketAddRequest.getQuantity())
                 .build();
         basketRepository.save(basket);
+    }
+
+    private void checkBasketAlreadyExists(User user, Option option) {
+        Optional<Basket> existsBasket = basketRepository.findByUserAndOption(user, option);
+        if (existsBasket.isPresent()) {
+            throw new ResourceAlreadyExistsException("Basket", existsBasket.get().getId());
+        }
+    }
+
+    private void checkBasketLimit(User user) {
+        Long basketCount = basketRepository.countByUser(user);
+        if (basketCount >= BASKET_LIMIT) {
+            throw new BasketOverLimitException("장바구니 개수가 최대입니다.", HttpStatus.BAD_REQUEST);
+        }
     }
 }

--- a/src/main/java/com/farmdora/farmdorabuyer/basket/service/BasketService.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/service/BasketService.java
@@ -2,12 +2,14 @@ package com.farmdora.farmdorabuyer.basket.service;
 
 import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
 import com.farmdora.farmdorabuyer.basket.repository.BasketRepository;
+import com.farmdora.farmdorabuyer.common.exception.ResourceAlreadyExistsException;
 import com.farmdora.farmdorabuyer.common.exception.ResourceNotFoundException;
 import com.farmdora.farmdorabuyer.entity.Basket;
 import com.farmdora.farmdorabuyer.entity.Option;
 import com.farmdora.farmdorabuyer.entity.User;
 import com.farmdora.farmdorabuyer.orders.repository.OptionRepository;
 import com.farmdora.farmdorabuyer.orders.repository.UserRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +28,11 @@ public class BasketService {
 
         Option option = optionRepository.findById(basketAddRequest.getOptionId())
                 .orElseThrow(() -> new ResourceNotFoundException("Option", basketAddRequest.getOptionId()));
+
+        Optional<Basket> existsBasket = basketRepository.findByUserAndOption(user, option);
+        if (existsBasket.isPresent()) {
+            throw new ResourceAlreadyExistsException("Basket", existsBasket.get().getId());
+        }
 
         Basket basket = Basket.builder()
                 .user(user)

--- a/src/main/java/com/farmdora/farmdorabuyer/basket/service/BasketService.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/service/BasketService.java
@@ -1,0 +1,37 @@
+package com.farmdora.farmdorabuyer.basket.service;
+
+import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
+import com.farmdora.farmdorabuyer.basket.repository.BasketRepository;
+import com.farmdora.farmdorabuyer.common.exception.ResourceNotFoundException;
+import com.farmdora.farmdorabuyer.entity.Basket;
+import com.farmdora.farmdorabuyer.entity.Option;
+import com.farmdora.farmdorabuyer.entity.User;
+import com.farmdora.farmdorabuyer.orders.repository.OptionRepository;
+import com.farmdora.farmdorabuyer.orders.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BasketService {
+    private final BasketRepository basketRepository;
+    private final UserRepository userRepository;
+    private final OptionRepository optionRepository;
+
+    public void addBasket(Integer userId, BasketRequestDto basketAddRequest) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", userId));
+
+        Option option = optionRepository.findById(basketAddRequest.getOptionId())
+                .orElseThrow(() -> new ResourceNotFoundException("Option", basketAddRequest.getOptionId()));
+
+        Basket basket = Basket.builder()
+                .user(user)
+                .option(option)
+                .quantity(basketAddRequest.getQuantity())
+                .build();
+        basketRepository.save(basket);
+    }
+}

--- a/src/main/java/com/farmdora/farmdorabuyer/common/response/SuccessMessage.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/common/response/SuccessMessage.java
@@ -9,7 +9,8 @@ public enum SuccessMessage {
     SEARCH_ORDER_SUCCESS("주문 목록 조회에 성공하였습니다."),
     SEARCH_ORDER_PAY_SUCCESS("주문 결제 정보 조회에 성공하였습니다."),
     REGISTER_REVIEW_SUCCESS("리뷰 등록에 성공하였습니다."),
-    CANCEL_ORDER_SUCCESS("주문 취소에 성공하였습니다.");
+    CANCEL_ORDER_SUCCESS("주문 취소에 성공하였습니다."),
+    ADD_BASKET_SUCCESS("장바구니 추가에 성공하였습니다.");
 
 
     private final String message;

--- a/src/main/java/com/farmdora/farmdorabuyer/entity/Basket.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/entity/Basket.java
@@ -2,19 +2,24 @@ package com.farmdora.farmdorabuyer.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+@Builder
 @Getter
+@Entity
+@ToString
 @AllArgsConstructor
 @NoArgsConstructor
-@ToString
-@Entity
 public class Basket {
 
     @Id
@@ -22,11 +27,13 @@ public class Basket {
     @Column(name = "basket_id")
     private Integer id;
 
-    @Column(nullable = false)
-    private Integer user_id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
-    @Column(nullable = false)
-    private Integer option_id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "option_id")
+    private Option option;
 
     @Column(nullable = false)
     private Integer quantity;

--- a/src/main/java/com/farmdora/farmdorabuyer/orders/repository/OptionRepository.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/orders/repository/OptionRepository.java
@@ -1,0 +1,7 @@
+package com.farmdora.farmdorabuyer.orders.repository;
+
+import com.farmdora.farmdorabuyer.entity.Option;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OptionRepository extends JpaRepository<Option, Integer> {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,16 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+
+ncp:
+  object-storage:
+    endpoint: https://kr.object.ncloudstorage.com
+    region: kr-standard
+    bucket: farmdora
+
+  image-optimizer:
+    project-id: Gv9VppsiR9
+    cdn-domain: aacblnby9780.edge.naverncp.com
+
+  access-key: ncp_iam_BPASKR5nKujGrW7C2yV5
+  secret-key: ncp_iam_BPKSKRPXwNzYCHv9zMJfroeR2XA8e47gQv

--- a/src/test/java/com/farmdora/farmdorabuyer/basket/controller/BasketControllerTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/basket/controller/BasketControllerTest.java
@@ -1,0 +1,73 @@
+package com.farmdora.farmdorabuyer.basket.controller;
+
+import static com.farmdora.farmdorabuyer.common.response.SuccessMessage.ADD_BASKET_SUCCESS;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
+import com.farmdora.farmdorabuyer.basket.service.BasketService;
+import com.farmdora.farmdorabuyer.common.exception.ResourceNotFoundException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = BasketController.class)
+class BasketControllerTest {
+
+    @MockitoBean
+    private BasketService basketService;
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    @DisplayName("장바구니 추가 API 테스트")
+    void testAddBasket() throws Exception {
+        // given
+        doNothing().when(basketService).addBasket(anyInt(), any(BasketRequestDto.class));
+
+        // when
+        // then
+        BasketRequestDto basketAddRequest = BasketRequestDto.builder()
+                .optionId(1)
+                .quantity(10)
+                .build();
+        mvc.perform(post("/api/basket")
+                        .content(new ObjectMapper().writeValueAsString(basketAddRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", equalTo(200)))
+                .andExpect(jsonPath("$.message", equalTo(ADD_BASKET_SUCCESS.getMessage())));
+    }
+
+    @Test
+    @DisplayName("장바구니 추가시 옵션이 존재하지 않을 경우 에러처리 테스트")
+    void testAddBasket_OptionNotFoundException() throws Exception {
+        // given
+        doThrow(new ResourceNotFoundException("Option", 1)).when(basketService).addBasket(anyInt(), any(BasketRequestDto.class));
+
+        // when
+        // then
+        BasketRequestDto basketAddRequest = BasketRequestDto.builder()
+                .optionId(1)
+                .quantity(10)
+                .build();
+        mvc.perform(post("/api/basket")
+                .content(new ObjectMapper().writeValueAsString(basketAddRequest))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status", equalTo(400)))
+                .andExpect(jsonPath("$.message", equalTo("Option 데이터가 존재하지 않습니다 : '1'")));
+    }
+}

--- a/src/test/java/com/farmdora/farmdorabuyer/basket/controller/BasketControllerTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/basket/controller/BasketControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
+import com.farmdora.farmdorabuyer.basket.exception.BasketOverLimitException;
 import com.farmdora.farmdorabuyer.basket.service.BasketService;
 import com.farmdora.farmdorabuyer.common.exception.ResourceAlreadyExistsException;
 import com.farmdora.farmdorabuyer.common.exception.ResourceNotFoundException;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -90,5 +92,25 @@ class BasketControllerTest {
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.status", equalTo(409)))
                 .andExpect(jsonPath("$.message", equalTo("Basket 이미 존재하는 데이터입니다. : '1'")));
+    }
+
+    @Test
+    @DisplayName("장바구니 추가시 16개가 넘을 경우 에러처리 테스트")
+    void testAddBasket_BasketOverLimitException() throws Exception {
+        // given
+        doThrow(new BasketOverLimitException("장바구니 개수가 최대입니다.", HttpStatus.BAD_REQUEST)).when(basketService).addBasket(anyInt(), any(BasketRequestDto.class));
+
+        // when
+        // then
+        BasketRequestDto basketAddRequest = BasketRequestDto.builder()
+                .optionId(1)
+                .quantity(10)
+                .build();
+        mvc.perform(post("/api/basket")
+                .content(new ObjectMapper().writeValueAsString(basketAddRequest))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status", equalTo(400)))
+                .andExpect(jsonPath("$.message", equalTo("장바구니 개수가 최대입니다.")));
     }
 }

--- a/src/test/java/com/farmdora/farmdorabuyer/basket/controller/BasketControllerTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/basket/controller/BasketControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
 import com.farmdora.farmdorabuyer.basket.service.BasketService;
+import com.farmdora.farmdorabuyer.common.exception.ResourceAlreadyExistsException;
 import com.farmdora.farmdorabuyer.common.exception.ResourceNotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -69,5 +70,25 @@ class BasketControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status", equalTo(400)))
                 .andExpect(jsonPath("$.message", equalTo("Option 데이터가 존재하지 않습니다 : '1'")));
+    }
+
+    @Test
+    @DisplayName("장바구니 추가시 장바구니가 이미 존재할 경우 에러처리 테스트")
+    void testAddBasket_ResourceAlreadyExistsException() throws Exception {
+        // given
+        doThrow(new ResourceAlreadyExistsException("Basket", 1)).when(basketService).addBasket(anyInt(), any(BasketRequestDto.class));
+
+        // when
+        // then
+        BasketRequestDto basketAddRequest = BasketRequestDto.builder()
+                .optionId(1)
+                .quantity(10)
+                .build();
+        mvc.perform(post("/api/basket")
+                        .content(new ObjectMapper().writeValueAsString(basketAddRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status", equalTo(409)))
+                .andExpect(jsonPath("$.message", equalTo("Basket 이미 존재하는 데이터입니다. : '1'")));
     }
 }

--- a/src/test/java/com/farmdora/farmdorabuyer/basket/service/BasketServiceTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/basket/service/BasketServiceTest.java
@@ -1,0 +1,85 @@
+package com.farmdora.farmdorabuyer.basket.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
+import com.farmdora.farmdorabuyer.basket.repository.BasketRepository;
+import com.farmdora.farmdorabuyer.common.exception.ResourceNotFoundException;
+import com.farmdora.farmdorabuyer.entity.Basket;
+import com.farmdora.farmdorabuyer.entity.Option;
+import com.farmdora.farmdorabuyer.entity.User;
+import com.farmdora.farmdorabuyer.orders.repository.OptionRepository;
+import com.farmdora.farmdorabuyer.orders.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BasketServiceTest {
+
+    @Mock
+    private BasketRepository basketRepository;
+
+    @Mock
+    private OptionRepository optionRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private BasketService basketService;
+
+    @Test
+    @DisplayName("장바구니 추가 서비스 레이어 테스트")
+    void testAddBasket() {
+        // given
+        User mockUser = User.builder()
+                .userId(1)
+                .build();
+        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+
+        Option mockOption = Option.builder()
+                .name("옵션")
+                .build();
+        when(optionRepository.findById(anyInt())).thenReturn(Optional.of(mockOption));
+
+        // when
+        BasketRequestDto basketAddRequest = BasketRequestDto.builder()
+                .optionId(1)
+                .quantity(10)
+                .build();
+        basketService.addBasket(1, basketAddRequest);
+
+        // then
+        verify(basketRepository, times(1)).save(any(Basket.class));
+    }
+
+    @Test
+    @DisplayName("장바구니 추가시 존재하지 않는 옵션일 경우 예외 발생")
+    void testAddBasket_OptionNotFoundException() {
+        // given
+        User mockUser = User.builder()
+                .userId(1)
+                .build();
+        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+        when(optionRepository.findById(anyInt())).thenReturn(Optional.empty());
+
+        // when
+        // then
+        BasketRequestDto basketAddRequest = BasketRequestDto.builder()
+                .optionId(1)
+                .quantity(10)
+                .build();
+        assertThatThrownBy(() -> basketService.addBasket(1, basketAddRequest))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/src/test/java/com/farmdora/farmdorabuyer/basket/service/BasketServiceTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/basket/service/BasketServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
+import com.farmdora.farmdorabuyer.basket.exception.BasketOverLimitException;
 import com.farmdora.farmdorabuyer.basket.repository.BasketRepository;
 import com.farmdora.farmdorabuyer.common.exception.ResourceAlreadyExistsException;
 import com.farmdora.farmdorabuyer.common.exception.ResourceNotFoundException;
@@ -112,5 +113,33 @@ class BasketServiceTest {
                 .build();
         assertThatThrownBy(() -> basketService.addBasket(1, basketAddRequest))
                 .isInstanceOf(ResourceAlreadyExistsException.class);
+    }
+
+    @Test
+    @DisplayName("장바구니 추가시 장바구니 목록이 이미 16개일 경우 예외 발생")
+    void testAddBasket_BasketOverLimitException() {
+        // given
+        User mockUser = User.builder()
+                .userId(1)
+                .build();
+        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+
+        Option mockOption = Option.builder()
+                .id(1)
+                .name("옵션")
+                .build();
+        when(optionRepository.findById(anyInt())).thenReturn(Optional.of(mockOption));
+
+        when(basketRepository.findByUserAndOption(any(User.class), any(Option.class))).thenReturn(Optional.empty());
+        when(basketRepository.countByUser(any(User.class))).thenReturn(16L);
+
+        // when
+        // then
+        BasketRequestDto basketAddRequest = BasketRequestDto.builder()
+                .optionId(1)
+                .quantity(10)
+                .build();
+        assertThatThrownBy(() -> basketService.addBasket(1, basketAddRequest))
+                .isInstanceOf(BasketOverLimitException.class);
     }
 }

--- a/src/test/java/com/farmdora/farmdorabuyer/basket/service/BasketServiceTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/basket/service/BasketServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
 import com.farmdora.farmdorabuyer.basket.repository.BasketRepository;
+import com.farmdora.farmdorabuyer.common.exception.ResourceAlreadyExistsException;
 import com.farmdora.farmdorabuyer.common.exception.ResourceNotFoundException;
 import com.farmdora.farmdorabuyer.entity.Basket;
 import com.farmdora.farmdorabuyer.entity.Option;
@@ -81,5 +82,35 @@ class BasketServiceTest {
                 .build();
         assertThatThrownBy(() -> basketService.addBasket(1, basketAddRequest))
                 .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("장바구니 추가시 이미 존재할 경우 예외 발생")
+    void testAddBasket_BasketAlreadyExistsException() {
+        // given
+        User mockUser = User.builder()
+                .userId(1)
+                .build();
+        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+
+        Option mockOption = Option.builder()
+                .name("옵션")
+                .build();
+        when(optionRepository.findById(anyInt())).thenReturn(Optional.of(mockOption));
+
+        Basket mockBasket = Basket.builder()
+                .user(mockUser)
+                .option(mockOption)
+                .build();
+        when(basketRepository.findByUserAndOption(any(User.class), any(Option.class))).thenReturn(Optional.of(mockBasket));
+
+        // when
+        // then
+        BasketRequestDto basketAddRequest = BasketRequestDto.builder()
+                .optionId(1)
+                .quantity(10)
+                .build();
+        assertThatThrownBy(() -> basketService.addBasket(1, basketAddRequest))
+                .isInstanceOf(ResourceAlreadyExistsException.class);
     }
 }

--- a/src/test/java/com/farmdora/farmdorabuyer/orders/repository/OrderOptionRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/orders/repository/OrderOptionRepositoryTest.java
@@ -9,8 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
-
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,14 +18,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class OrderOptionRepositoryTest {
 
     @Autowired
-    private TestEntityManager testEntityManager;
+    private TestEntityManager em;
 
     @Autowired
     private OrderOptionRepository orderOptionRepository;
 
     private Order order;
-    LocalDateTime orderTime = order.getCreatedDate();
-
     private Pay pay;
     private PayStatus payStatus;
     private OrderStatus orderStatus;
@@ -37,30 +33,30 @@ class OrderOptionRepositoryTest {
     void setUp() {
         User user = User.builder()
                 .build();
-        testEntityManager.persist(user);
+        em.persist(user);
 
-        OrderStatus orderStatus = OrderStatus.builder()
+        orderStatus = OrderStatus.builder()
                 .id((short) 2) // 배송중
                 .build();
-        testEntityManager.persist(orderStatus);
+        em.persist(orderStatus);
 
-        Order order = Order.builder()
+        order = Order.builder()
                 .user(user)
                 .status(orderStatus)
                 .build();
-        testEntityManager.persist(order);
+        em.persist(order);
 
         Sale sale = Sale.builder()
                 .title("제주 삼다수")
                 .build();
-        testEntityManager.persist(sale);
+        em.persist(sale);
 
-        SaleFile saleFile = SaleFile.builder()
+        saleFile = SaleFile.builder()
                 .sale(sale)
                 .saveFile("sample_image.jpg")
                 .isMain(true)
                 .build();
-        testEntityManager.persist(saleFile);
+        em.persist(saleFile);
 
         Option option1 = Option.builder()
                 .sale(sale)
@@ -72,8 +68,8 @@ class OrderOptionRepositoryTest {
                 .name("1L")
                 .price(2000)
                 .build();
-        testEntityManager.persist(option1);
-        testEntityManager.persist(option2);
+        em.persist(option1);
+        em.persist(option2);
 
         OrderOption orderOption1 = OrderOption.builder()
                 .order(order)
@@ -81,7 +77,7 @@ class OrderOptionRepositoryTest {
                 .quantity(3)
                 .price(option1.getPrice() * 3)
                 .build();
-        testEntityManager.persist(orderOption1);
+        em.persist(orderOption1);
 
         OrderOption orderOption2 = OrderOption.builder()
                 .order(order)
@@ -89,21 +85,21 @@ class OrderOptionRepositoryTest {
                 .quantity(5)
                 .price(option2.getPrice() * 5)
                 .build();
-        testEntityManager.persist(orderOption2);
+        em.persist(orderOption2);
 
-        PayStatus payStatus = PayStatus.builder()
+        payStatus = PayStatus.builder()
                 .id((short) 2) // 결제완료
                 .build();
-        testEntityManager.persist(payStatus);
+        em.persist(payStatus);
 
-        Pay pay = Pay.builder()
+        pay = Pay.builder()
                 .order(order)
                 .status(payStatus)
                 .amount(orderOption1.getPrice() + orderOption2.getPrice())
                 .build();
-        testEntityManager.persist(pay);
+        em.persist(pay);
 
-        testEntityManager.flush();
+        em.flush();
     }
 
     @Test
@@ -135,7 +131,7 @@ class OrderOptionRepositoryTest {
         assertThat(foundSale1.getTitle()).isEqualTo("제주 삼다수");
         assertThat(foundSale2.getTitle()).isEqualTo("제주 삼다수");
 
-        assertThat(order.getCreatedDate()).isEqualTo(orderTime);
+        assertThat(order.getCreatedDate()).isEqualTo(order.getCreatedDate());
         assertThat(pay.getAmount()).isEqualTo(13000);
         assertThat(payStatus.getId()).isEqualTo((short) 2);
         assertThat(orderStatus.getId()).isEqualTo((short) 2);

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,3 +4,16 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+
+ncp:
+  object-storage:
+    endpoint: https://kr.object.ncloudstorage.com
+    region: kr-standard
+    bucket: farmdora
+
+  image-optimizer:
+    project-id: Gv9VppsiR9
+    cdn-domain: aacblnby9780.edge.naverncp.com
+
+  access-key: ncp_iam_BPASKR5nKujGrW7C2yV5
+  secret-key: ncp_iam_BPKSKRPXwNzYCHv9zMJfroeR2XA8e47gQv


### PR DESCRIPTION
## 📌 작업 내용
- [x] 장바구니 추가 API 구현
- [x] 테스트 케이스 추가
- [x] OrderOptionRepository 쿼리메서드 테스트 케이스 수정
- [x] 공통 Yaml에 NCP 설정 코드 추가
 
<br>

## 💡 필수확인 API 요청

### API 요청 URL
`POST` `/api/basket`

### 요청 데이터
`optionId`: 장바구니 아이디
`quantity`: 선택한 장바구니 아이템 수량

```json
{
    "optionId": 1,
    "quantity": 10
}
```

### 응답데이터
```json
{
    "status": 200,
    "message": "장바구니 추가에 성공하였습니다.",
    "data": null
}
```

<br>

## 📆 작업기간
2025.04.23

<br>

## 📷 스크린샷(선택)

<br>

## ✅ 참고 사항(선택)