### PR TITLE
[FDORA-22] feat: 장바구니 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/farmdora/farmdorabuyer/basket/controller/BasketController.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/controller/BasketController.java
@@ -1,13 +1,17 @@
 package com.farmdora.farmdorabuyer.basket.controller;
 
 import static com.farmdora.farmdorabuyer.common.response.SuccessMessage.ADD_BASKET_SUCCESS;
+import static com.farmdora.farmdorabuyer.common.response.SuccessMessage.GET_BASKETS_SUCCESS;
 
 import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
+import com.farmdora.farmdorabuyer.basket.dto.BasketResponseDto;
 import com.farmdora.farmdorabuyer.basket.service.BasketService;
 import com.farmdora.farmdorabuyer.common.response.HttpResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,9 +25,19 @@ public class BasketController {
 
     @PostMapping
     public ResponseEntity<?> addBasket(BasketRequestDto basketRequest) {
+        // TODO Security 구현 완료 후 대체 예정
         Integer userId = 1;
         basketService.addBasket(userId, basketRequest);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, ADD_BASKET_SUCCESS.getMessage(), null));
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getBaskets() {
+        // TODO Security 구현 완료 후 대체 예정
+        Integer userId = 1;
+        List<BasketResponseDto> baskets = basketService.getBaskets(userId);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, GET_BASKETS_SUCCESS.getMessage(), baskets));
     }
 }

--- a/src/main/java/com/farmdora/farmdorabuyer/basket/dto/BasketResponseDto.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/dto/BasketResponseDto.java
@@ -1,0 +1,35 @@
+package com.farmdora.farmdorabuyer.basket.dto;
+
+import com.farmdora.farmdorabuyer.entity.Basket;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class BasketResponseDto {
+    private Integer basketId;
+    private Integer saleId;
+    private String title;
+    private String option;
+    private Integer quantity;
+    private Integer price;
+
+    public static BasketResponseDto fromEntity(Basket basket) {
+        return BasketResponseDto.builder()
+                .basketId(basket.getId())
+                .saleId(basket.getOption().getSale().getId())
+                .title(basket.getOption().getSale().getTitle())
+                .option(basket.getOption().getName())
+                .quantity(basket.getQuantity())
+                .price(basket.getOption().getPrice())
+                .build();
+    }
+}

--- a/src/main/java/com/farmdora/farmdorabuyer/basket/repository/BasketRepository.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/repository/BasketRepository.java
@@ -3,9 +3,14 @@ package com.farmdora.farmdorabuyer.basket.repository;
 import com.farmdora.farmdorabuyer.entity.Basket;
 import com.farmdora.farmdorabuyer.entity.Option;
 import com.farmdora.farmdorabuyer.entity.User;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BasketRepository extends JpaRepository<Basket, Integer> {
     Optional<Basket> findByUserAndOption(User user, Option option);
+
+    @EntityGraph(attributePaths = {"option", "option.sale"})
+    List<Basket> findAllByUser(User user);
 }

--- a/src/main/java/com/farmdora/farmdorabuyer/basket/service/BasketService.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/service/BasketService.java
@@ -1,6 +1,7 @@
 package com.farmdora.farmdorabuyer.basket.service;
 
 import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
+import com.farmdora.farmdorabuyer.basket.dto.BasketResponseDto;
 import com.farmdora.farmdorabuyer.basket.repository.BasketRepository;
 import com.farmdora.farmdorabuyer.common.exception.ResourceAlreadyExistsException;
 import com.farmdora.farmdorabuyer.common.exception.ResourceNotFoundException;
@@ -9,6 +10,7 @@ import com.farmdora.farmdorabuyer.entity.Option;
 import com.farmdora.farmdorabuyer.entity.User;
 import com.farmdora.farmdorabuyer.orders.repository.OptionRepository;
 import com.farmdora.farmdorabuyer.orders.repository.UserRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -40,5 +42,16 @@ public class BasketService {
                 .quantity(basketAddRequest.getQuantity())
                 .build();
         basketRepository.save(basket);
+    }
+
+    @Transactional(readOnly = true)
+    public List<BasketResponseDto> getBaskets(Integer userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", userId));
+
+        List<Basket> baskets = basketRepository.findAllByUser(user);
+        return baskets.stream()
+                .map(BasketResponseDto::fromEntity)
+                .toList();
     }
 }

--- a/src/main/java/com/farmdora/farmdorabuyer/common/response/SuccessMessage.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/common/response/SuccessMessage.java
@@ -10,7 +10,8 @@ public enum SuccessMessage {
     SEARCH_ORDER_PAY_SUCCESS("주문 결제 정보 조회에 성공하였습니다."),
     REGISTER_REVIEW_SUCCESS("리뷰 등록에 성공하였습니다."),
     CANCEL_ORDER_SUCCESS("주문 취소에 성공하였습니다."),
-    ADD_BASKET_SUCCESS("장바구니 추가에 성공하였습니다.");
+    ADD_BASKET_SUCCESS("장바구니 추가에 성공하였습니다."),
+    GET_BASKETS_SUCCESS("장바구니 목록 조회에 성공하였습니다.");
 
 
     private final String message;

--- a/src/test/java/com/farmdora/farmdorabuyer/basket/controller/BasketControllerTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/basket/controller/BasketControllerTest.java
@@ -1,20 +1,25 @@
 package com.farmdora.farmdorabuyer.basket.controller;
 
 import static com.farmdora.farmdorabuyer.common.response.SuccessMessage.ADD_BASKET_SUCCESS;
+import static com.farmdora.farmdorabuyer.common.response.SuccessMessage.GET_BASKETS_SUCCESS;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
+import com.farmdora.farmdorabuyer.basket.dto.BasketResponseDto;
 import com.farmdora.farmdorabuyer.basket.service.BasketService;
 import com.farmdora.farmdorabuyer.common.exception.ResourceAlreadyExistsException;
 import com.farmdora.farmdorabuyer.common.exception.ResourceNotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -90,5 +95,36 @@ class BasketControllerTest {
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.status", equalTo(409)))
                 .andExpect(jsonPath("$.message", equalTo("Basket 이미 존재하는 데이터입니다. : '1'")));
+    }
+
+    @Test
+    @DisplayName("사용자의 장바구니 목록 조회 API 테스트")
+    void testGetBaskets() throws Exception {
+        // given
+        List<BasketResponseDto> baskets = List.of(
+                BasketResponseDto.builder()
+                        .basketId(1)
+                        .title("상품1")
+                        .option("옵션1")
+                        .quantity(1)
+                        .price(1000)
+                        .build(),
+                BasketResponseDto.builder()
+                        .basketId(2)
+                        .title("상품2")
+                        .option("옵션2")
+                        .quantity(2)
+                        .price(2000)
+                        .build()
+        );
+        when(basketService.getBaskets(anyInt())).thenReturn(baskets);
+
+        // when
+        // then
+        mvc.perform(get("/api/basket"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", equalTo(200)))
+                .andExpect(jsonPath("$.message", equalTo(GET_BASKETS_SUCCESS.getMessage())))
+                .andExpect(jsonPath("$.data.size()", equalTo(2)));
     }
 }

--- a/src/test/java/com/farmdora/farmdorabuyer/basket/repository/BasketRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/basket/repository/BasketRepositoryTest.java
@@ -1,0 +1,83 @@
+package com.farmdora.farmdorabuyer.basket.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.farmdora.farmdorabuyer.entity.Basket;
+import com.farmdora.farmdorabuyer.entity.Option;
+import com.farmdora.farmdorabuyer.entity.User;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@DataJpaTest
+class BasketRepositoryTest {
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private BasketRepository basketRepository;
+
+    @Test
+    @DisplayName("findByUserAndOption() 쿼리메서드 테스트")
+    void testFindByUserAndOption() {
+        // given
+        User user = new User();
+        em.persist(user);
+
+        Option option = new Option();
+        em.persist(option);
+
+        Basket basket = Basket.builder()
+                .user(user)
+                .option(option)
+                .quantity(2)
+                .build();
+        em.persist(basket);
+
+        em.flush();
+        em.clear();
+
+        // when
+        Optional<Basket> savedBasket = basketRepository.findByUserAndOption(user, option);
+
+        // then
+        assertThat(savedBasket.isPresent()).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("findAllByUser() 쿼리메서드 테스트")
+    void testFindAllByUser() {
+        // given
+        User user = new User();
+        em.persist(user);
+
+        Option option = Option.builder()
+                .name("옵션")
+                .build();
+        em.persist(option);
+
+        Basket basket1 = Basket.builder()
+                .user(user)
+                .option(option)
+                .quantity(2)
+                .build();
+        Basket basket2 = Basket.builder()
+                .user(user)
+                .option(option)
+                .quantity(4)
+                .build();
+        em.persist(basket1);
+        em.persist(basket2);
+
+        // when
+        List<Basket> baskets = basketRepository.findAllByUser(user);
+
+        // then
+        assertThat(baskets.size()).isEqualTo(2);
+    }
+}

--- a/src/test/java/com/farmdora/farmdorabuyer/basket/service/BasketServiceTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/basket/service/BasketServiceTest.java
@@ -1,5 +1,6 @@
 package com.farmdora.farmdorabuyer.basket.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -8,14 +9,17 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
+import com.farmdora.farmdorabuyer.basket.dto.BasketResponseDto;
 import com.farmdora.farmdorabuyer.basket.repository.BasketRepository;
 import com.farmdora.farmdorabuyer.common.exception.ResourceAlreadyExistsException;
 import com.farmdora.farmdorabuyer.common.exception.ResourceNotFoundException;
 import com.farmdora.farmdorabuyer.entity.Basket;
 import com.farmdora.farmdorabuyer.entity.Option;
+import com.farmdora.farmdorabuyer.entity.Sale;
 import com.farmdora.farmdorabuyer.entity.User;
 import com.farmdora.farmdorabuyer.orders.repository.OptionRepository;
 import com.farmdora.farmdorabuyer.orders.repository.UserRepository;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -112,5 +116,49 @@ class BasketServiceTest {
                 .build();
         assertThatThrownBy(() -> basketService.addBasket(1, basketAddRequest))
                 .isInstanceOf(ResourceAlreadyExistsException.class);
+    }
+
+    @Test
+    @DisplayName("사용자의 장바구니 목록 조회")
+    void testGetBaskets() {
+        // given
+        User mockUser = User.builder()
+                .userId(1)
+                .build();
+        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+
+        Sale mockSale = Sale.builder()
+                .id(1)
+                .title("상품")
+                .build();
+
+        Option mockOption = Option.builder()
+                .id(1)
+                .sale(mockSale)
+                .name("옵션")
+                .build();
+
+        List<Basket> baskets = List.of(
+                Basket.builder()
+                        .user(mockUser)
+                        .quantity(2)
+                        .option(mockOption)
+                        .build(),
+                Basket.builder()
+                        .user(mockUser)
+                        .quantity(10)
+                        .option(mockOption)
+                        .build()
+        );
+        when(basketRepository.findAllByUser(any(User.class))).thenReturn(baskets);
+
+        // when
+        List<BasketResponseDto> result = basketService.getBaskets(1);
+
+        // then
+        BasketResponseDto basket1 = result.get(0);
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(basket1.getTitle()).isEqualTo("상품");
+        assertThat(basket1.getQuantity()).isEqualTo(2);
     }
 }

--- a/src/test/java/com/farmdora/farmdorabuyer/basket/service/BasketServiceTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/basket/service/BasketServiceTest.java
@@ -123,6 +123,11 @@ class BasketServiceTest {
     @DisplayName("장바구니 추가시 장바구니 목록이 이미 16개일 경우 예외 발생")
     void testAddBasket_BasketOverLimitException() {
         // given
+        User mockUser = User.builder()
+                .userId(1)
+                .build();
+        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+
         Option mockOption = Option.builder()
                 .id(1)
                 .name("옵션")


### PR DESCRIPTION
## 📌 작업 내용
- [x] 장바구니 목록 조회 API 구현
- [x] 테스트 케이스 작성

<br>

## 💡 필수확인

### API URL
`GET` `/api/basket`

### 응답데이터
`basketId`: 장바구니 아이디
`saleId`: 상품 아이디
`title`: 상품명
`option`: 옵션명
`quantity`: 담은 개수
`price`: 옵션 가격
```json
{
    "status": 200,
    "message": "장바구니 목록 조회에 성공하였습니다.",
    "data": [
        {
            "basketId": 1,
            "saleId": 1,
            "title": "상품0000001",
            "option": "옵션A-000001",
            "quantity": 10,
            "price": 3190
        },
        {
            "basketId": 2,
            "saleId": 1000000,
            "title": "상품1000000",
            "option": "옵션A-100000",
            "quantity": 10,
            "price": 7640
        }
    ]
}
```


<br>

## 📆 작업기간
2025.04.24

<br>

## 📷 스크린샷(선택)

<br>

## ✅ 참고 사항(선택)