### PR TITLE
[FDORA-38] feat: 장바구니 상품 삭제 및 수량 수정 API 구현

### DIFF
--- a/src/main/java/com/farmdora/farmdorabuyer/basket/controller/BasketController.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/controller/BasketController.java
@@ -3,6 +3,7 @@ package com.farmdora.farmdorabuyer.basket.controller;
 import static com.farmdora.farmdorabuyer.common.response.SuccessMessage.ADD_BASKET_SUCCESS;
 import static com.farmdora.farmdorabuyer.common.response.SuccessMessage.GET_BASKETS_SUCCESS;
 import static com.farmdora.farmdorabuyer.common.response.SuccessMessage.REMOVE_BASKET_SUCCESS;
+import static com.farmdora.farmdorabuyer.common.response.SuccessMessage.UPDATE_BASKET_QUANTITY_SUCCESS;
 
 import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
 import com.farmdora.farmdorabuyer.basket.dto.BasketResponseDto;
@@ -16,7 +17,9 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -43,6 +46,7 @@ public class BasketController {
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, GET_BASKETS_SUCCESS.getMessage(), baskets));
     }
+
     @DeleteMapping("/{basketId}")
     public ResponseEntity<?> removeBasket(@PathVariable("basketId") Integer basketId) {
         // TODO Security 구현 완료 후 대체 예정
@@ -52,4 +56,13 @@ public class BasketController {
                 .body(new HttpResponse(HttpStatus.OK, REMOVE_BASKET_SUCCESS.getMessage(), null));
     }
 
+    @PutMapping("/{basketId}")
+    public ResponseEntity<?> updateQuantity(@PathVariable("basketId") Integer basketId,
+                                            @RequestParam int quantity) {
+        // TODO Security 구현 완료 후 대체 예정
+        Integer userId = 1;
+        basketService.updateBasketQuantity(userId, basketId, quantity);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, UPDATE_BASKET_QUANTITY_SUCCESS.getMessage(), null));
+    }
 }

--- a/src/main/java/com/farmdora/farmdorabuyer/basket/controller/BasketController.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/controller/BasketController.java
@@ -2,6 +2,7 @@ package com.farmdora.farmdorabuyer.basket.controller;
 
 import static com.farmdora.farmdorabuyer.common.response.SuccessMessage.ADD_BASKET_SUCCESS;
 import static com.farmdora.farmdorabuyer.common.response.SuccessMessage.GET_BASKETS_SUCCESS;
+import static com.farmdora.farmdorabuyer.common.response.SuccessMessage.REMOVE_BASKET_SUCCESS;
 
 import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
 import com.farmdora.farmdorabuyer.basket.dto.BasketResponseDto;
@@ -11,7 +12,9 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -40,4 +43,13 @@ public class BasketController {
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, GET_BASKETS_SUCCESS.getMessage(), baskets));
     }
+    @DeleteMapping("/{basketId}")
+    public ResponseEntity<?> removeBasket(@PathVariable("basketId") Integer basketId) {
+        // TODO Security 구현 완료 후 대체 예정
+        Integer userId = 1;
+        basketService.removeBasket(userId, basketId);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, REMOVE_BASKET_SUCCESS.getMessage(), null));
+    }
+
 }

--- a/src/main/java/com/farmdora/farmdorabuyer/basket/exception/QuantityOverLimitException.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/exception/QuantityOverLimitException.java
@@ -1,0 +1,10 @@
+package com.farmdora.farmdorabuyer.basket.exception;
+
+import com.farmdora.farmdorabuyer.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class QuantityOverLimitException extends BaseException {
+    public QuantityOverLimitException() {
+        super("옵션의 수량보다 많이 담을 수 없습니다.", HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/farmdora/farmdorabuyer/basket/repository/BasketRepository.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/repository/BasketRepository.java
@@ -13,4 +13,6 @@ public interface BasketRepository extends JpaRepository<Basket, Integer> {
 
     @EntityGraph(attributePaths = {"option", "option.sale"})
     List<Basket> findAllByUser(User user);
+
+    Optional<Basket> findByIdAndUser(Integer basketId, User user);
 }

--- a/src/main/java/com/farmdora/farmdorabuyer/basket/service/BasketService.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/service/BasketService.java
@@ -2,6 +2,7 @@ package com.farmdora.farmdorabuyer.basket.service;
 
 import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
 import com.farmdora.farmdorabuyer.basket.dto.BasketResponseDto;
+import com.farmdora.farmdorabuyer.basket.exception.QuantityOverLimitException;
 import com.farmdora.farmdorabuyer.basket.repository.BasketRepository;
 import com.farmdora.farmdorabuyer.common.exception.ResourceAlreadyExistsException;
 import com.farmdora.farmdorabuyer.common.exception.ResourceNotFoundException;
@@ -31,10 +32,8 @@ public class BasketService {
         Option option = optionRepository.findById(basketAddRequest.getOptionId())
                 .orElseThrow(() -> new ResourceNotFoundException("Option", basketAddRequest.getOptionId()));
 
-        Optional<Basket> existsBasket = basketRepository.findByUserAndOption(user, option);
-        if (existsBasket.isPresent()) {
-            throw new ResourceAlreadyExistsException("Basket", existsBasket.get().getId());
-        }
+        checkOptionQuantity(basketAddRequest.getQuantity(), option.getQuantity());
+        checkBasketAlreadyExists(user, option);
 
         Basket basket = Basket.builder()
                 .user(user)
@@ -42,6 +41,19 @@ public class BasketService {
                 .quantity(basketAddRequest.getQuantity())
                 .build();
         basketRepository.save(basket);
+    }
+
+    private void checkOptionQuantity(int basketQuantity, int optionQuantity) {
+        if (basketQuantity > optionQuantity) {
+            throw new QuantityOverLimitException();
+        }
+    }
+
+    private void checkBasketAlreadyExists(User user, Option option) {
+        Optional<Basket> existsBasket = basketRepository.findByUserAndOption(user, option);
+        if (existsBasket.isPresent()) {
+            throw new ResourceAlreadyExistsException("Basket", existsBasket.get().getId());
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/farmdora/farmdorabuyer/basket/service/BasketService.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/service/BasketService.java
@@ -54,4 +54,14 @@ public class BasketService {
                 .map(BasketResponseDto::fromEntity)
                 .toList();
     }
+    public void removeBasket(Integer userId, Integer basketId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", userId));
+
+        Basket basket = basketRepository.findByIdAndUser(basketId, user)
+                .orElseThrow(() -> new ResourceNotFoundException("Basket", basketId));
+
+        basketRepository.delete(basket);
+    }
+
 }

--- a/src/main/java/com/farmdora/farmdorabuyer/basket/service/BasketService.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/service/BasketService.java
@@ -54,6 +54,7 @@ public class BasketService {
                 .map(BasketResponseDto::fromEntity)
                 .toList();
     }
+
     public void removeBasket(Integer userId, Integer basketId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("User", userId));
@@ -64,4 +65,13 @@ public class BasketService {
         basketRepository.delete(basket);
     }
 
+    public void updateBasketQuantity(Integer userId, Integer basketId, int quantity) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", userId));
+
+        Basket basket = basketRepository.findByIdAndUser(basketId, user)
+                .orElseThrow(() -> new ResourceNotFoundException("Basket", basketId));
+
+        basket.updateQuantity(quantity);
+    }
 }

--- a/src/main/java/com/farmdora/farmdorabuyer/common/response/SuccessMessage.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/common/response/SuccessMessage.java
@@ -11,7 +11,6 @@ public enum SuccessMessage {
     REGISTER_REVIEW_SUCCESS("리뷰 등록에 성공하였습니다."),
     CANCEL_ORDER_SUCCESS("주문 취소에 성공하였습니다."),
     ADD_BASKET_SUCCESS("장바구니 추가에 성공하였습니다."),
-    GET_BASKETS_SUCCESS("장바구니 목록 조회에 성공하였습니다.");
     GET_BASKETS_SUCCESS("장바구니 목록 조회에 성공하였습니다."),
     REMOVE_BASKET_SUCCESS("장바구니 삭제에 성공하였습니다."),
     UPDATE_BASKET_QUANTITY_SUCCESS("장바구니 수량 수정에 성공하였습니다.");

--- a/src/main/java/com/farmdora/farmdorabuyer/common/response/SuccessMessage.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/common/response/SuccessMessage.java
@@ -12,6 +12,9 @@ public enum SuccessMessage {
     CANCEL_ORDER_SUCCESS("주문 취소에 성공하였습니다."),
     ADD_BASKET_SUCCESS("장바구니 추가에 성공하였습니다."),
     GET_BASKETS_SUCCESS("장바구니 목록 조회에 성공하였습니다.");
+    GET_BASKETS_SUCCESS("장바구니 목록 조회에 성공하였습니다."),
+    REMOVE_BASKET_SUCCESS("장바구니 삭제에 성공하였습니다."),
+    UPDATE_BASKET_QUANTITY_SUCCESS("장바구니 수량 수정에 성공하였습니다.");
 
 
     private final String message;

--- a/src/main/java/com/farmdora/farmdorabuyer/entity/Basket.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/entity/Basket.java
@@ -37,5 +37,9 @@ public class Basket {
 
     @Column(nullable = false)
     private Integer quantity;
+
+    public void updateQuantity(int quantity) {
+        this.quantity = quantity;
+    }
 }
 

--- a/src/test/java/com/farmdora/farmdorabuyer/basket/controller/BasketControllerTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/basket/controller/BasketControllerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/src/test/java/com/farmdora/farmdorabuyer/basket/controller/BasketControllerTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/basket/controller/BasketControllerTest.java
@@ -9,6 +9,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -19,6 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
 import com.farmdora.farmdorabuyer.basket.dto.BasketResponseDto;
+import com.farmdora.farmdorabuyer.basket.exception.QuantityOverLimitException;
 import com.farmdora.farmdorabuyer.basket.service.BasketService;
 import com.farmdora.farmdorabuyer.common.exception.ResourceAlreadyExistsException;
 import com.farmdora.farmdorabuyer.common.exception.ResourceNotFoundException;
@@ -59,6 +62,8 @@ class BasketControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status", equalTo(200)))
                 .andExpect(jsonPath("$.message", equalTo(ADD_BASKET_SUCCESS.getMessage())));
+
+        verify(basketService, times(1)).addBasket(anyInt(), any(BasketRequestDto.class));
     }
 
     @Test
@@ -79,6 +84,26 @@ class BasketControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status", equalTo(400)))
                 .andExpect(jsonPath("$.message", equalTo("Option 데이터가 존재하지 않습니다 : '1'")));
+    }
+
+    @Test
+    @DisplayName("장바구니 추가시 담은 수량이 재고수를 넘은 경우 에러처리 테스트")
+    void testAddBasket_QuantityOverLimitException() throws Exception {
+        // given
+        doThrow(new QuantityOverLimitException()).when(basketService).addBasket(anyInt(), any(BasketRequestDto.class));
+
+        // when
+        // then
+        BasketRequestDto basketAddRequest = BasketRequestDto.builder()
+                .optionId(1)
+                .quantity(10)
+                .build();
+        mvc.perform(post("/api/basket")
+                        .content(new ObjectMapper().writeValueAsString(basketAddRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status", equalTo(400)))
+                .andExpect(jsonPath("$.message", equalTo("옵션의 수량보다 많이 담을 수 없습니다.")));
     }
 
     @Test

--- a/src/test/java/com/farmdora/farmdorabuyer/basket/controller/BasketControllerTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/basket/controller/BasketControllerTest.java
@@ -2,12 +2,15 @@ package com.farmdora.farmdorabuyer.basket.controller;
 
 import static com.farmdora.farmdorabuyer.common.response.SuccessMessage.ADD_BASKET_SUCCESS;
 import static com.farmdora.farmdorabuyer.common.response.SuccessMessage.GET_BASKETS_SUCCESS;
+import static com.farmdora.farmdorabuyer.common.response.SuccessMessage.REMOVE_BASKET_SUCCESS;
+import static com.farmdora.farmdorabuyer.common.response.SuccessMessage.UPDATE_BASKET_QUANTITY_SUCCESS;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -126,5 +129,63 @@ class BasketControllerTest {
                 .andExpect(jsonPath("$.status", equalTo(200)))
                 .andExpect(jsonPath("$.message", equalTo(GET_BASKETS_SUCCESS.getMessage())))
                 .andExpect(jsonPath("$.data.size()", equalTo(2)));
+    }
+
+    @Test
+    @DisplayName("사용자의 장바구니 삭제 API 테스트")
+    void testRemoveBasket() throws Exception {
+        // given
+        doNothing().when(basketService).removeBasket(anyInt(), anyInt());
+
+        // when
+        // then
+        mvc.perform(delete("/api/basket/{basketId}", 1))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", equalTo(200)))
+                .andExpect(jsonPath("$.message", equalTo(REMOVE_BASKET_SUCCESS.getMessage())));
+    }
+
+    @Test
+    @DisplayName("사용자의 장바구니 삭제시 장바구니가 없을 경우 에러처리 테스트")
+    void testRemoveBasket_ResourceNotFoundException() throws Exception {
+        // given
+        doThrow(new ResourceNotFoundException("Basket", 1)).when(basketService).removeBasket(anyInt(), anyInt());
+
+        // when
+        // then
+        mvc.perform(delete("/api/basket/{basketId}", 1))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status", equalTo(400)))
+                .andExpect(jsonPath("$.message", equalTo("Basket 데이터가 존재하지 않습니다 : '1'")));
+    }
+
+    @Test
+    @DisplayName("사용자의 장바구니 수량 수정 API 테스트")
+    void testUpdateQuantity() throws Exception{
+        // given
+        doNothing().when(basketService).updateBasketQuantity(anyInt(), anyInt(), anyInt());
+
+        // when
+        // then
+        mvc.perform(put("/api/basket/{basketId}", 1)
+                .param("quantity", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", equalTo(200)))
+                .andExpect(jsonPath("$.message", equalTo(UPDATE_BASKET_QUANTITY_SUCCESS.getMessage())));
+    }
+
+    @Test
+    @DisplayName("사용자의 장바구니 수량 수정시 장바구니가 존재하지 않을 경우 에러처리 테스트")
+    void testUpdateQuantity_ResourceNotFoundException() throws Exception{
+        // given
+        doThrow(new ResourceNotFoundException("Basket", 1)).when(basketService).updateBasketQuantity(anyInt(), anyInt(), anyInt());
+
+        // when
+        // then
+        mvc.perform(put("/api/basket/{basketId}", 1)
+                        .param("quantity", "10"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status", equalTo(400)))
+                .andExpect(jsonPath("$.message", equalTo("Basket 데이터가 존재하지 않습니다 : '1'")));
     }
 }

--- a/src/test/java/com/farmdora/farmdorabuyer/basket/controller/BasketControllerTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/basket/controller/BasketControllerTest.java
@@ -28,6 +28,7 @@ import com.farmdora.farmdorabuyer.common.exception.ResourceNotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -42,176 +43,188 @@ class BasketControllerTest {
     private BasketService basketService;
 
     @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
     private MockMvc mvc;
 
-    @Test
+    @Nested
     @DisplayName("장바구니 추가 API 테스트")
-    void testAddBasket() throws Exception {
-        // given
-        doNothing().when(basketService).addBasket(anyInt(), any(BasketRequestDto.class));
+    class AddBasketTests {
 
-        // when
-        // then
-        BasketRequestDto basketAddRequest = BasketRequestDto.builder()
-                .optionId(1)
-                .quantity(10)
-                .build();
-        mvc.perform(post("/api/basket")
-                        .content(new ObjectMapper().writeValueAsString(basketAddRequest))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status", equalTo(200)))
-                .andExpect(jsonPath("$.message", equalTo(ADD_BASKET_SUCCESS.getMessage())));
+        private BasketRequestDto basketAddRequest = BasketRequestDto.builder()
+                    .optionId(1)
+                    .quantity(10)
+                    .build();
 
-        verify(basketService, times(1)).addBasket(anyInt(), any(BasketRequestDto.class));
+        @Test
+        @DisplayName("장바구니 추가 성공")
+        void testAddBasket() throws Exception {
+            // given
+            doNothing().when(basketService).addBasket(anyInt(), any(BasketRequestDto.class));
+
+            // when
+            // then
+            mvc.perform(post("/api/basket")
+                            .content(objectMapper.writeValueAsString(basketAddRequest))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status", equalTo(200)))
+                    .andExpect(jsonPath("$.message", equalTo(ADD_BASKET_SUCCESS.getMessage())));
+
+            verify(basketService, times(1)).addBasket(anyInt(), any(BasketRequestDto.class));
+        }
+
+        @Test
+        @DisplayName("장바구니 추가시 옵션이 존재하지 않을 경우 에러처리 테스트")
+        void testAddBasket_OptionNotFoundException() throws Exception {
+            // given
+            doThrow(new ResourceNotFoundException("Option", 1)).when(basketService).addBasket(anyInt(), any(BasketRequestDto.class));
+
+            // when
+            // then
+            mvc.perform(post("/api/basket")
+                            .content(objectMapper.writeValueAsString(basketAddRequest))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status", equalTo(400)))
+                    .andExpect(jsonPath("$.message", equalTo("Option 데이터가 존재하지 않습니다 : '1'")));
+        }
+
+        @Test
+        @DisplayName("장바구니 추가시 담은 수량이 재고수를 넘은 경우 에러처리 테스트")
+        void testAddBasket_QuantityOverLimitException() throws Exception {
+            // given
+            doThrow(new QuantityOverLimitException()).when(basketService).addBasket(anyInt(), any(BasketRequestDto.class));
+
+            // when
+            // then
+            mvc.perform(post("/api/basket")
+                            .content(objectMapper.writeValueAsString(basketAddRequest))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status", equalTo(400)))
+                    .andExpect(jsonPath("$.message", equalTo("옵션의 수량보다 많이 담을 수 없습니다.")));
+        }
+
+        @Test
+        @DisplayName("장바구니 추가시 장바구니가 이미 존재할 경우 에러처리 테스트")
+        void testAddBasket_ResourceAlreadyExistsException() throws Exception {
+            // given
+            doThrow(new ResourceAlreadyExistsException("Basket", 1)).when(basketService).addBasket(anyInt(), any(BasketRequestDto.class));
+
+            // when
+            // then
+            mvc.perform(post("/api/basket")
+                            .content(objectMapper.writeValueAsString(basketAddRequest))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.status", equalTo(409)))
+                    .andExpect(jsonPath("$.message", equalTo("Basket 이미 존재하는 데이터입니다. : '1'")));
+        }
     }
 
-    @Test
-    @DisplayName("장바구니 추가시 옵션이 존재하지 않을 경우 에러처리 테스트")
-    void testAddBasket_OptionNotFoundException() throws Exception {
-        // given
-        doThrow(new ResourceNotFoundException("Option", 1)).when(basketService).addBasket(anyInt(), any(BasketRequestDto.class));
-
-        // when
-        // then
-        BasketRequestDto basketAddRequest = BasketRequestDto.builder()
-                .optionId(1)
-                .quantity(10)
-                .build();
-        mvc.perform(post("/api/basket")
-                .content(new ObjectMapper().writeValueAsString(basketAddRequest))
-                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status", equalTo(400)))
-                .andExpect(jsonPath("$.message", equalTo("Option 데이터가 존재하지 않습니다 : '1'")));
-    }
-
-    @Test
-    @DisplayName("장바구니 추가시 담은 수량이 재고수를 넘은 경우 에러처리 테스트")
-    void testAddBasket_QuantityOverLimitException() throws Exception {
-        // given
-        doThrow(new QuantityOverLimitException()).when(basketService).addBasket(anyInt(), any(BasketRequestDto.class));
-
-        // when
-        // then
-        BasketRequestDto basketAddRequest = BasketRequestDto.builder()
-                .optionId(1)
-                .quantity(10)
-                .build();
-        mvc.perform(post("/api/basket")
-                        .content(new ObjectMapper().writeValueAsString(basketAddRequest))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status", equalTo(400)))
-                .andExpect(jsonPath("$.message", equalTo("옵션의 수량보다 많이 담을 수 없습니다.")));
-    }
-
-    @Test
-    @DisplayName("장바구니 추가시 장바구니가 이미 존재할 경우 에러처리 테스트")
-    void testAddBasket_ResourceAlreadyExistsException() throws Exception {
-        // given
-        doThrow(new ResourceAlreadyExistsException("Basket", 1)).when(basketService).addBasket(anyInt(), any(BasketRequestDto.class));
-
-        // when
-        // then
-        BasketRequestDto basketAddRequest = BasketRequestDto.builder()
-                .optionId(1)
-                .quantity(10)
-                .build();
-        mvc.perform(post("/api/basket")
-                        .content(new ObjectMapper().writeValueAsString(basketAddRequest))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.status", equalTo(409)))
-                .andExpect(jsonPath("$.message", equalTo("Basket 이미 존재하는 데이터입니다. : '1'")));
-    }
-
-    @Test
+    @Nested
     @DisplayName("사용자의 장바구니 목록 조회 API 테스트")
-    void testGetBaskets() throws Exception {
-        // given
-        List<BasketResponseDto> baskets = List.of(
-                BasketResponseDto.builder()
-                        .basketId(1)
-                        .title("상품1")
-                        .option("옵션1")
-                        .quantity(1)
-                        .price(1000)
-                        .build(),
-                BasketResponseDto.builder()
-                        .basketId(2)
-                        .title("상품2")
-                        .option("옵션2")
-                        .quantity(2)
-                        .price(2000)
-                        .build()
-        );
-        when(basketService.getBaskets(anyInt())).thenReturn(baskets);
+    class GetBasketsTests {
 
-        // when
-        // then
-        mvc.perform(get("/api/basket"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status", equalTo(200)))
-                .andExpect(jsonPath("$.message", equalTo(GET_BASKETS_SUCCESS.getMessage())))
-                .andExpect(jsonPath("$.data.size()", equalTo(2)));
+        @Test
+        @DisplayName("사용자의 장바구니 목록 조회 성공")
+        void testGetBaskets() throws Exception {
+            // given
+            List<BasketResponseDto> baskets = List.of(
+                    BasketResponseDto.builder()
+                            .basketId(1)
+                            .title("상품1")
+                            .option("옵션1")
+                            .quantity(1)
+                            .price(1000)
+                            .build(),
+                    BasketResponseDto.builder()
+                            .basketId(2)
+                            .title("상품2")
+                            .option("옵션2")
+                            .quantity(2)
+                            .price(2000)
+                            .build()
+            );
+            when(basketService.getBaskets(anyInt())).thenReturn(baskets);
+
+            // when
+            // then
+            mvc.perform(get("/api/basket"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status", equalTo(200)))
+                    .andExpect(jsonPath("$.message", equalTo(GET_BASKETS_SUCCESS.getMessage())))
+                    .andExpect(jsonPath("$.data.size()", equalTo(2)));
+        }
     }
 
-    @Test
+    @Nested
     @DisplayName("사용자의 장바구니 삭제 API 테스트")
-    void testRemoveBasket() throws Exception {
-        // given
-        doNothing().when(basketService).removeBasket(anyInt(), anyInt());
+    class RemoveBasketsTest {
 
-        // when
-        // then
-        mvc.perform(delete("/api/basket/{basketId}", 1))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status", equalTo(200)))
-                .andExpect(jsonPath("$.message", equalTo(REMOVE_BASKET_SUCCESS.getMessage())));
+        @Test
+        @DisplayName("사용자의 장바구니 삭제 성공")
+        void testRemoveBasket() throws Exception {
+            // given
+            doNothing().when(basketService).removeBasket(anyInt(), anyInt());
+
+            // when
+            // then
+            mvc.perform(delete("/api/basket/{basketId}", 1))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status", equalTo(200)))
+                    .andExpect(jsonPath("$.message", equalTo(REMOVE_BASKET_SUCCESS.getMessage())));
+        }
+
+        @Test
+        @DisplayName("사용자의 장바구니 삭제시 장바구니가 없을 경우 에러처리 테스트")
+        void testRemoveBasket_ResourceNotFoundException() throws Exception {
+            // given
+            doThrow(new ResourceNotFoundException("Basket", 1)).when(basketService).removeBasket(anyInt(), anyInt());
+
+            // when
+            // then
+            mvc.perform(delete("/api/basket/{basketId}", 1))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status", equalTo(400)))
+                    .andExpect(jsonPath("$.message", equalTo("Basket 데이터가 존재하지 않습니다 : '1'")));
+        }
     }
 
-    @Test
-    @DisplayName("사용자의 장바구니 삭제시 장바구니가 없을 경우 에러처리 테스트")
-    void testRemoveBasket_ResourceNotFoundException() throws Exception {
-        // given
-        doThrow(new ResourceNotFoundException("Basket", 1)).when(basketService).removeBasket(anyInt(), anyInt());
-
-        // when
-        // then
-        mvc.perform(delete("/api/basket/{basketId}", 1))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status", equalTo(400)))
-                .andExpect(jsonPath("$.message", equalTo("Basket 데이터가 존재하지 않습니다 : '1'")));
-    }
-
-    @Test
+    @Nested
     @DisplayName("사용자의 장바구니 수량 수정 API 테스트")
-    void testUpdateQuantity() throws Exception{
-        // given
-        doNothing().when(basketService).updateBasketQuantity(anyInt(), anyInt(), anyInt());
+    class UpdateQuantityTests {
 
-        // when
-        // then
-        mvc.perform(put("/api/basket/{basketId}", 1)
-                .param("quantity", "10"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status", equalTo(200)))
-                .andExpect(jsonPath("$.message", equalTo(UPDATE_BASKET_QUANTITY_SUCCESS.getMessage())));
-    }
+        @Test
+        @DisplayName("사용자의 장바구니 수량 수정 성공")
+        void testUpdateQuantity() throws Exception{
+            // given
+            doNothing().when(basketService).updateBasketQuantity(anyInt(), anyInt(), anyInt());
 
-    @Test
-    @DisplayName("사용자의 장바구니 수량 수정시 장바구니가 존재하지 않을 경우 에러처리 테스트")
-    void testUpdateQuantity_ResourceNotFoundException() throws Exception{
-        // given
-        doThrow(new ResourceNotFoundException("Basket", 1)).when(basketService).updateBasketQuantity(anyInt(), anyInt(), anyInt());
+            // when
+            // then
+            mvc.perform(put("/api/basket/{basketId}", 1)
+                    .param("quantity", "10"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status", equalTo(200)))
+                    .andExpect(jsonPath("$.message", equalTo(UPDATE_BASKET_QUANTITY_SUCCESS.getMessage())));
+        }
 
-        // when
-        // then
-        mvc.perform(put("/api/basket/{basketId}", 1)
-                        .param("quantity", "10"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status", equalTo(400)))
-                .andExpect(jsonPath("$.message", equalTo("Basket 데이터가 존재하지 않습니다 : '1'")));
+        @Test
+        @DisplayName("사용자의 장바구니 수량 수정시 장바구니가 존재하지 않을 경우 에러처리 테스트")
+        void testUpdateQuantity_ResourceNotFoundException() throws Exception{
+            // given
+            doThrow(new ResourceNotFoundException("Basket", 1)).when(basketService).updateBasketQuantity(anyInt(), anyInt(), anyInt());
+
+            // when
+            // then
+            mvc.perform(put("/api/basket/{basketId}", 1)
+                            .param("quantity", "10"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status", equalTo(400)))
+                    .andExpect(jsonPath("$.message", equalTo("Basket 데이터가 존재하지 않습니다 : '1'")));
+        }
     }
 }

--- a/src/test/java/com/farmdora/farmdorabuyer/basket/repository/BasketRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/basket/repository/BasketRepositoryTest.java
@@ -80,4 +80,34 @@ class BasketRepositoryTest {
         // then
         assertThat(baskets.size()).isEqualTo(2);
     }
+
+    @Test
+    @DisplayName("findByIdAndUser() 쿼리메서드 테스트")
+    void testFindByIdAndUser() {
+        // given
+        User user = new User();
+        em.persist(user);
+
+        Option option = Option.builder()
+                .name("옵션")
+                .build();
+        em.persist(option);
+
+        Basket basket = Basket.builder()
+                .user(user)
+                .option(option)
+                .quantity(2)
+                .build();
+        em.persist(basket);
+
+        em.flush();
+        em.clear();
+
+        // when
+        Optional<Basket> savedBasket = basketRepository.findByIdAndUser(basket.getId(), user);
+
+        // then
+        assertThat(savedBasket.isPresent()).isEqualTo(true);
+        assertThat(savedBasket.get().getQuantity()).isEqualTo(2);
+    }
 }

--- a/src/test/java/com/farmdora/farmdorabuyer/basket/service/BasketServiceTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/basket/service/BasketServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
 import com.farmdora.farmdorabuyer.basket.dto.BasketResponseDto;
+import com.farmdora.farmdorabuyer.basket.exception.QuantityOverLimitException;
 import com.farmdora.farmdorabuyer.basket.repository.BasketRepository;
 import com.farmdora.farmdorabuyer.common.exception.ResourceAlreadyExistsException;
 import com.farmdora.farmdorabuyer.common.exception.ResourceNotFoundException;
@@ -54,6 +55,7 @@ class BasketServiceTest {
 
         Option mockOption = Option.builder()
                 .name("옵션")
+                .quantity(20)
                 .build();
         when(optionRepository.findById(anyInt())).thenReturn(Optional.of(mockOption));
 
@@ -89,6 +91,31 @@ class BasketServiceTest {
     }
 
     @Test
+    @DisplayName("장바구니 추가시 존재하지 않는 옵션일 경우 예외 발생")
+    void testAddBasket_QuantityOverLimitException() {
+        // given
+        User mockUser = User.builder()
+                .userId(1)
+                .build();
+        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+
+        Option mockOption = Option.builder()
+                .name("옵션")
+                .quantity(1)
+                .build();
+        when(optionRepository.findById(anyInt())).thenReturn(Optional.of(mockOption));
+
+        // when
+        // then
+        BasketRequestDto basketAddRequest = BasketRequestDto.builder()
+                .optionId(1)
+                .quantity(10)
+                .build();
+        assertThatThrownBy(() -> basketService.addBasket(1, basketAddRequest))
+                .isInstanceOf(QuantityOverLimitException.class);
+    }
+
+    @Test
     @DisplayName("장바구니 추가시 이미 존재할 경우 예외 발생")
     void testAddBasket_BasketAlreadyExistsException() {
         // given
@@ -99,6 +126,7 @@ class BasketServiceTest {
 
         Option mockOption = Option.builder()
                 .name("옵션")
+                .quantity(20)
                 .build();
         when(optionRepository.findById(anyInt())).thenReturn(Optional.of(mockOption));
 

--- a/src/test/java/com/farmdora/farmdorabuyer/basket/service/BasketServiceTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/basket/service/BasketServiceTest.java
@@ -161,4 +161,83 @@ class BasketServiceTest {
         assertThat(basket1.getTitle()).isEqualTo("상품");
         assertThat(basket1.getQuantity()).isEqualTo(2);
     }
+
+    @Test
+    @DisplayName("사용자의 특정 장바구니 삭제 서비스 레이어 테스트")
+    void testRemoveBasket() {
+        // given
+        User mockUser = User.builder()
+                .userId(1)
+                .build();
+        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+
+        Basket mockBasket = Basket.builder()
+                .id(1)
+                .user(mockUser)
+                .build();
+        when(basketRepository.findByIdAndUser(anyInt(), any(User.class))).thenReturn(Optional.of(mockBasket));
+
+        // when
+        basketService.removeBasket(1, 1);
+
+        // then
+        verify(basketRepository, times(1)).delete(any(Basket.class));
+    }
+
+    @Test
+    @DisplayName("사용자의 특정 장바구니 삭제시 장바구니가 존재하지 않을 경우 예외 발생 테스트")
+    void testRemoveBasket_ResourceNotFoundException() {
+        // given
+        User mockUser = User.builder()
+                .userId(1)
+                .build();
+        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+
+        when(basketRepository.findByIdAndUser(anyInt(), any(User.class))).thenReturn(Optional.empty());
+
+        // when
+        // then
+        assertThatThrownBy(() -> basketService.removeBasket(1, 1))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("사용자의 장바구니 수량 수정 서비스 레이어 테스트")
+    void testUpdateBasketQuantity() {
+        // given
+        User mockUser = User.builder()
+                .userId(1)
+                .build();
+        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+
+        Basket mockBasket = Basket.builder()
+                .id(1)
+                .user(mockUser)
+                .quantity(1)
+                .build();
+        when(basketRepository.findByIdAndUser(anyInt(), any(User.class))).thenReturn(Optional.of(mockBasket));
+
+        // when
+        basketService.updateBasketQuantity(1, 1, 10);
+
+        // then
+        assertThat(mockBasket.getQuantity()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("사용자의 장바구니 수량 수정시 장바구니가 존재하지 않을 경우 예외 발생 테스트")
+    void testUpdateBasketQuantity_ResourceNotFoundException() {
+        // given
+        User mockUser = User.builder()
+                .userId(1)
+                .build();
+        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+
+        when(basketRepository.findByIdAndUser(anyInt(), any(User.class))).thenReturn(Optional.empty());
+
+        // when
+        // then
+        assertThatThrownBy(() -> basketService.updateBasketQuantity(1, 1, 10))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
 }


### PR DESCRIPTION
## 📌 작업 내용
- [x] 장바구니 상품 삭제 API 구현
- [x] 장바구니 상품 수량 수정 API 구현
- [x] 테스트 케이스 추가

<br>

## 💡 필수확인 1. 장바구니 상품 삭제

### URL
`DELETE` `/api/basket/{basketId}`

### 응답 본문

```json
{
    "status": 200,
    "message": "장바구니 삭제에 성공하였습니다.",
    "data": null
}
```

## 💡 필수확인 2. 장바구니 수량 수정

### URL
`PUT` `/api/basket/{basketId}`

### 파라미터
`quantity` : 수정할 수량

### 응답 본문
```json
{
    "status": 200,
    "message": "장바구니 수량 수정에 성공하였습니다.",
    "data": null
}
```

<br>

## 📆 작업기간
2025.04.24

<br>

## 📷 스크린샷(선택)

<br>

## ✅ 참고 사항(선택)