### PR TITLE
[FDORA-19] feat: 배너 사진 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/farmdora/farmdorabuyer/common/response/SuccessMessage.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/common/response/SuccessMessage.java
@@ -15,7 +15,8 @@ public enum SuccessMessage {
     REMOVE_BASKET_SUCCESS("장바구니 삭제에 성공하였습니다."),
     UPDATE_BASKET_QUANTITY_SUCCESS("장바구니 수량 수정에 성공하였습니다."),
     CREATE_ORDER_SUCCESS("주문에 성공하였습니다."),
-    ADD_LIKE_SUCCESS("찜 수정에 성공하였습니다.");
+    ADD_LIKE_SUCCESS("찜 수정에 성공하였습니다."),
+    GET_POPUPS_SUCCESS("팝업 목록 조회에 성공하였습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/farmdora/farmdorabuyer/entity/Popup.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/entity/Popup.java
@@ -7,7 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,7 +28,7 @@ public class Popup extends BaseTimeEntity {
     @Column(name = "popup_id")
     private Integer id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "type_id")
     private PopupType type;
 

--- a/src/main/java/com/farmdora/farmdorabuyer/popup/controller/PopupController.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/popup/controller/PopupController.java
@@ -1,0 +1,26 @@
+package com.farmdora.farmdorabuyer.popup.controller;
+
+import static com.farmdora.farmdorabuyer.common.response.SuccessMessage.GET_POPUPS_SUCCESS;
+
+import com.farmdora.farmdorabuyer.common.response.HttpResponse;
+import com.farmdora.farmdorabuyer.popup.dto.PopupDTO;
+import com.farmdora.farmdorabuyer.popup.service.PopupService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class PopupController {
+    private final PopupService popupService;
+
+    @GetMapping("/api/popup")
+    public ResponseEntity<?> getPopups() {
+        List<PopupDTO> popups = popupService.getPopups();
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, GET_POPUPS_SUCCESS.getMessage(), popups));
+    }
+}

--- a/src/main/java/com/farmdora/farmdorabuyer/popup/dto/PopupDTO.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/popup/dto/PopupDTO.java
@@ -1,0 +1,22 @@
+package com.farmdora.farmdorabuyer.popup.dto;
+
+import com.farmdora.farmdorabuyer.entity.Popup;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class PopupDTO {
+    private Integer id;
+    private String imageUrl;
+
+    public static PopupDTO fromEntity(Popup popup, String imagePath, String imageType) {
+        return PopupDTO.builder()
+                .id(popup.getId())
+                .imageUrl(String.format("%s%s%s", imagePath, popup.getSaveFile(), imageType))
+                .build();
+    }
+}

--- a/src/main/java/com/farmdora/farmdorabuyer/popup/repository/PopupRepository.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/popup/repository/PopupRepository.java
@@ -1,0 +1,10 @@
+package com.farmdora.farmdorabuyer.popup.repository;
+
+import com.farmdora.farmdorabuyer.entity.Popup;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PopupRepository extends JpaRepository<Popup, Integer> {
+    List<Popup> findByEndDateGreaterThanEqual(LocalDateTime now);
+}

--- a/src/main/java/com/farmdora/farmdorabuyer/popup/service/PopupService.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/popup/service/PopupService.java
@@ -1,0 +1,32 @@
+package com.farmdora.farmdorabuyer.popup.service;
+
+import com.farmdora.farmdorabuyer.entity.Popup;
+import com.farmdora.farmdorabuyer.popup.dto.PopupDTO;
+import com.farmdora.farmdorabuyer.popup.repository.PopupRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PopupService {
+
+    @Value("${ncp.image.path}")
+    private String imagePath;
+
+    @Value("${ncp.image.type}")
+    private String imageType;
+
+    private final PopupRepository popupRepository;
+
+    @Transactional(readOnly = true)
+    public List<PopupDTO> getPopups() {
+        List<Popup> popups = popupRepository.findByEndDateGreaterThanEqual(LocalDateTime.now());
+        return popups.stream()
+                .map(p -> PopupDTO.fromEntity(p, imagePath, imageType))
+                .toList();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,10 @@ ncp:
     region: kr-standard
     bucket: farmdora
 
+  image:
+    path: https://zcbg41sa9729.edge.naverncp.com/O8XfcLSSm6/product/
+    type: ?type=h&h=192&ttype=png
+
   image-optimizer:
     project-id: Gv9VppsiR9
     cdn-domain: aacblnby9780.edge.naverncp.com

--- a/src/test/java/com/farmdora/farmdorabuyer/popup/controller/PopupControllerTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/popup/controller/PopupControllerTest.java
@@ -1,0 +1,52 @@
+package com.farmdora.farmdorabuyer.popup.controller;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.farmdora.farmdorabuyer.common.response.SuccessMessage;
+import com.farmdora.farmdorabuyer.popup.dto.PopupDTO;
+import com.farmdora.farmdorabuyer.popup.service.PopupService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = PopupController.class)
+class PopupControllerTest {
+
+    @MockitoBean
+    private PopupService popupService;
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    @DisplayName("팝업 목록 조회 ")
+    void testGetPopups() throws Exception {
+        // given
+        List<PopupDTO> popups = List.of(
+                PopupDTO.builder()
+                        .id(1)
+                        .imageUrl("imageUrl")
+                        .build(),
+                PopupDTO.builder()
+                        .id(2)
+                        .imageUrl("imageUrl")
+                        .build()
+        );
+        when(popupService.getPopups()).thenReturn(popups);
+
+        // when
+        // then
+        mvc.perform(get("/api/popup"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", equalTo(200)))
+                .andExpect(jsonPath("$.message", equalTo(SuccessMessage.GET_POPUPS_SUCCESS.getMessage())));
+    }
+}

--- a/src/test/java/com/farmdora/farmdorabuyer/popup/repository/PopupRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/popup/repository/PopupRepositoryTest.java
@@ -1,0 +1,51 @@
+package com.farmdora.farmdorabuyer.popup.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.farmdora.farmdorabuyer.config.AuditConfig;
+import com.farmdora.farmdorabuyer.entity.Popup;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(AuditConfig.class)
+class PopupRepositoryTest {
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private PopupRepository popupRepository;
+
+    @Test
+    @DisplayName("findByEndDateGreaterThanEqual() 쿼리메서드 테스트")
+    void testFindByEndDateGreaterThanEqual() {
+        // given
+        Popup popup1 = Popup.builder()
+                .startDate(LocalDateTime.now().minusDays(7))
+                .endDate(LocalDateTime.now().plusDays(7))
+                .build();
+        em.persist(popup1);
+
+        Popup popup2 = Popup.builder()
+                .startDate(LocalDateTime.now().minusDays(7))
+                .endDate(LocalDateTime.now().minusDays(1))
+                .build();
+        em.persist(popup2);
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<Popup> popups = popupRepository.findByEndDateGreaterThanEqual(LocalDateTime.now());
+
+        // then
+        assertThat(popups.size()).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/farmdora/farmdorabuyer/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/popup/service/PopupServiceTest.java
@@ -1,0 +1,9 @@
+package com.farmdora.farmdorabuyer.popup.service;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PopupServiceTest {
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -11,6 +11,10 @@ ncp:
     region: kr-standard
     bucket: farmdora
 
+  image:
+    path: https://zcbg41sa9729.edge.naverncp.com/O8XfcLSSm6/product/
+    type: ?type=h&h=192&ttype=png
+
   image-optimizer:
     project-id: Gv9VppsiR9
     cdn-domain: aacblnby9780.edge.naverncp.com


### PR DESCRIPTION
## 📌 작업 내용
- [x] 배너 사진 목록 조회 API구현
- [x] 테스트 케이스 추가

<br>

## 💡 필수확인
### URL
`GET` `/api/popup`

### 응답 데이터
```json
{
    "status": 200,
    "message": "팝업 목록 조회에 성공하였습니다.",
    "data": [
        {
            "id": 31,
            "imageUrl": "https://zcbg41sa9729.edge.naverncp.com/O8XfcLSSm6/product/0213f99f-ac9d-423f-b641-20c45ee89883?type=h&h=192&ttype=png"
        },
        {
            "id": 32,
            "imageUrl": "https://zcbg41sa9729.edge.naverncp.com/O8XfcLSSm6/product/0213f99f-ac9d-423f-b641-20c45ee89883?type=h&h=192&ttype=png"
        }
    ]
}
```
<br>

## 📆 작업기간
2025.05.02

<br>

## 📷 스크린샷(선택)

<br>

## ✅ 참고 사항(선택)