### PR TITLE
[FDORA-158] feat: 시큐리티 적용 및 장바구니 삭제/조회 로직 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     // database
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // jasypt
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
@@ -39,6 +40,12 @@ dependencies {
     // AWS S3 SDK
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.595' // 최신 버전으로 수정 가능
 
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/farmdora/farmdorabuyer/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,51 @@
+package com.farmdora.farmdorabuyer.auth;
+
+import static com.farmdora.farmdorabuyer.auth.JwtConstants.*;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String token = request.getHeader(AUTHORIZATION_HEADER);
+        if (token != null) {
+            token = token.replace(TOKEN_PREFIX, "");
+        }
+
+        if (token != null && jwtUtil.validateToken(token)) {
+            int userId = jwtUtil.getUserId(token);
+            Collection<? extends GrantedAuthority> authorities = jwtUtil.getAuthorities(token);
+
+            if (Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_KEY + token))) {
+                log.warn("블랙리스트 토큰 접근 차단");
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return;
+            }
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userId, null, jwtUtil.getAuthorities(token));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/farmdora/farmdorabuyer/auth/JwtConstants.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/auth/JwtConstants.java
@@ -1,0 +1,7 @@
+package com.farmdora.farmdorabuyer.auth;
+
+public interface JwtConstants {
+    String AUTHORIZATION_HEADER = "Authorization";
+    String TOKEN_PREFIX = "Bearer ";
+    String BLACKLIST_KEY = "blacklist:";
+}

--- a/src/main/java/com/farmdora/farmdorabuyer/auth/JwtUtil.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/auth/JwtUtil.java
@@ -1,0 +1,61 @@
+package com.farmdora.farmdorabuyer.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+
+    public JwtUtil(@Value("${spring.jwt.secret}") String secret) {
+        this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8),
+                Jwts.SIG.HS512.key()
+                        .build()
+                        .getAlgorithm());
+    }
+
+    public Integer getUserId(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload().get("userId", Integer.class);
+    }
+
+    public Collection<? extends GrantedAuthority> getAuthorities(String token) {
+        String role = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("role", String.class);
+        return List.of(new SimpleGrantedAuthority(role));
+    }
+
+    public boolean validateToken(String token) {
+        try{
+            Claims claims = Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token).getPayload();
+            return !claims.getExpiration().before(new Date());
+        } catch (JwtException | IllegalArgumentException e) {
+            log.error("Jwt 요효성 검사 실패: {}" , e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/farmdora/farmdorabuyer/auth/SecurityConfig.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/auth/SecurityConfig.java
@@ -1,0 +1,71 @@
+package com.farmdora.farmdorabuyer.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtUtil jwtUtil;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(Customizer.withDefaults())
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests((auth)->
+                        auth
+                                // TODO
+                                .requestMatchers("/api/basket/**").hasAnyRole("USER", "SELLER")
+                                .requestMatchers("/api/like/**").hasAnyRole("USER", "SELLER")
+                                .requestMatchers("/api/my/user/**").hasRole("USER")
+                                .requestMatchers("/api/order/**").hasRole("USER")
+                                .anyRequest().permitAll())
+                .addFilterBefore(new JwtAuthenticationFilter(jwtUtil, redisTemplate), UsernamePasswordAuthenticationFilter.class)
+                .sessionManagement((session)-> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/src/main/java/com/farmdora/farmdorabuyer/basket/controller/BasketController.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/controller/BasketController.java
@@ -9,8 +9,12 @@ import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
 import com.farmdora.farmdorabuyer.basket.dto.BasketResponseDto;
 import com.farmdora.farmdorabuyer.basket.service.BasketService;
 import com.farmdora.farmdorabuyer.common.response.HttpResponse;
+import com.farmdora.farmdorabuyer.common.response.PageResponseDTO;
+import java.security.Principal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -31,37 +35,33 @@ public class BasketController {
     private final BasketService basketService;
 
     @PostMapping
-    public ResponseEntity<?> addBasket(@RequestBody BasketRequestDto basketRequest) {
-        // TODO Security 구현 완료 후 대체 예정
-        Integer userId = 1;
+    public ResponseEntity<?> addBasket(Principal principal, @RequestBody BasketRequestDto basketRequest) {
+        Integer userId = Integer.parseInt(principal.getName());
         basketService.addBasket(userId, basketRequest);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, ADD_BASKET_SUCCESS.getMessage(), null));
     }
 
     @GetMapping
-    public ResponseEntity<?> getBaskets() {
-        // TODO Security 구현 완료 후 대체 예정
-        Integer userId = 1;
-        List<BasketResponseDto> baskets = basketService.getBaskets(userId);
+    public ResponseEntity<?> getBaskets(Principal principal, @PageableDefault(size = 5) Pageable pageable) {
+        Integer userId = Integer.parseInt(principal.getName());
+        PageResponseDTO<BasketResponseDto> baskets = basketService.getBaskets(userId, pageable);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, GET_BASKETS_SUCCESS.getMessage(), baskets));
     }
 
-    @DeleteMapping("/{basketId}")
-    public ResponseEntity<?> removeBasket(@PathVariable("basketId") Integer basketId) {
-        // TODO Security 구현 완료 후 대체 예정
-        Integer userId = 1;
-        basketService.removeBasket(userId, basketId);
-        return ResponseEntity.ok()
-                .body(new HttpResponse(HttpStatus.OK, REMOVE_BASKET_SUCCESS.getMessage(), null));
+    @DeleteMapping
+    public ResponseEntity<?> removeBaskets(Principal principal, @RequestBody List<Integer> basketIds) {
+        Integer userId = Integer.parseInt(principal.getName());
+        basketService.removeBaskets(userId, basketIds);
+        return ResponseEntity.ok().body(new HttpResponse(HttpStatus.OK, REMOVE_BASKET_SUCCESS.getMessage(), null));
     }
 
     @PutMapping("/{basketId}")
-    public ResponseEntity<?> updateQuantity(@PathVariable("basketId") Integer basketId,
+    public ResponseEntity<?> updateQuantity(Principal principal,
+                                            @PathVariable("basketId") Integer basketId,
                                             @RequestParam int quantity) {
-        // TODO Security 구현 완료 후 대체 예정
-        Integer userId = 1;
+        Integer userId = Integer.parseInt(principal.getName());
         basketService.updateBasketQuantity(userId, basketId, quantity);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, UPDATE_BASKET_QUANTITY_SUCCESS.getMessage(), null));

--- a/src/main/java/com/farmdora/farmdorabuyer/basket/dto/BasketResponseDto.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/dto/BasketResponseDto.java
@@ -1,6 +1,5 @@
 package com.farmdora.farmdorabuyer.basket.dto;
 
-import com.farmdora.farmdorabuyer.entity.Basket;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,15 +20,5 @@ public class BasketResponseDto {
     private String option;
     private Integer quantity;
     private Integer price;
-
-    public static BasketResponseDto fromEntity(Basket basket) {
-        return BasketResponseDto.builder()
-                .basketId(basket.getId())
-                .saleId(basket.getOption().getSale().getId())
-                .title(basket.getOption().getSale().getTitle())
-                .option(basket.getOption().getName())
-                .quantity(basket.getQuantity())
-                .price(basket.getOption().getPrice())
-                .build();
-    }
+    private String imageUrl;
 }

--- a/src/main/java/com/farmdora/farmdorabuyer/basket/service/BasketService.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/service/BasketService.java
@@ -4,8 +4,10 @@ import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
 import com.farmdora.farmdorabuyer.basket.dto.BasketResponseDto;
 import com.farmdora.farmdorabuyer.basket.exception.QuantityOverLimitException;
 import com.farmdora.farmdorabuyer.basket.exception.BasketOverLimitException;
+import com.farmdora.farmdorabuyer.common.exception.AccessDeniedException;
 import com.farmdora.farmdorabuyer.common.exception.ResourceAlreadyExistsException;
 import com.farmdora.farmdorabuyer.common.exception.ResourceNotFoundException;
+import com.farmdora.farmdorabuyer.common.response.PageResponseDTO;
 import com.farmdora.farmdorabuyer.entity.Basket;
 import com.farmdora.farmdorabuyer.entity.Option;
 import com.farmdora.farmdorabuyer.entity.User;
@@ -15,6 +17,9 @@ import com.farmdora.farmdorabuyer.orders.repository.UserRepository;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +33,12 @@ public class BasketService {
     private final OptionRepository optionRepository;
 
     private static final int BASKET_LIMIT = 16;
+
+    @Value("${ncp.image.path}")
+    private String imagePath;
+
+    @Value("${ncp.image.type}")
+    private String imageType;
 
     public void addBasket(Integer userId, BasketRequestDto basketAddRequest) {
         User user = userRepository.findById(userId)
@@ -69,14 +80,18 @@ public class BasketService {
     }
 
     @Transactional(readOnly = true)
-    public List<BasketResponseDto> getBaskets(Integer userId) {
+    public PageResponseDTO<BasketResponseDto> getBaskets(Integer userId, Pageable pageable) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("User", userId));
 
-        List<Basket> baskets = basketRepository.findAllByUser(user);
-        return baskets.stream()
-                .map(BasketResponseDto::fromEntity)
-                .toList();
+        Page<BasketResponseDto> baskets = basketRepository.findAllWithMainImageByUser(user, pageable);
+        for (BasketResponseDto basket : baskets.getContent()) {
+            if (basket.getImageUrl() != null) {
+                basket.setImageUrl(imagePath + basket.getImageUrl() + imageType);
+            }
+        }
+
+        return new PageResponseDTO<>(baskets, baskets.getContent());
     }
 
     public void removeBasket(Integer userId, Integer basketId) {
@@ -87,6 +102,18 @@ public class BasketService {
                 .orElseThrow(() -> new ResourceNotFoundException("Basket", basketId));
 
         basketRepository.delete(basket);
+    }
+
+    public void removeBaskets(Integer userId, List<Integer> basketIds) {
+        List<Basket> baskets = basketRepository.findAllById(basketIds);
+
+        for (Basket basket : baskets) {
+            if (!basket.getUser().getUserId().equals(userId)) {
+                throw new AccessDeniedException();
+            }
+        }
+
+        basketRepository.deleteAll(baskets);
     }
 
     public void updateBasketQuantity(Integer userId, Integer basketId, int quantity) {

--- a/src/main/java/com/farmdora/farmdorabuyer/config/JasyptConfig.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/config/JasyptConfig.java
@@ -1,0 +1,34 @@
+package com.farmdora.farmdorabuyer.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class JasyptConfig {
+
+    @Value("${jasypt.encryptor.password}")
+    private String password;
+
+    @Bean("jasyptEncryptor")
+    public StringEncryptor stringEncryptor() {
+        PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
+        SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+        config.setPassword(password);
+        config.setAlgorithm("PBEWithMD5AndDES");
+        config.setKeyObtentionIterations("1000");
+        config.setPoolSize("1");
+        config.setProviderName("SunJCE");
+        config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
+        config.setIvGeneratorClassName("org.jasypt.iv.NoIvGenerator");
+        config.setStringOutputType("base64");
+        encryptor.setConfig(config);
+
+        return encryptor;
+    }
+}

--- a/src/main/java/com/farmdora/farmdorabuyer/config/RedisConfig.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/config/RedisConfig.java
@@ -1,0 +1,38 @@
+package com.farmdora.farmdorabuyer.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/farmdora/farmdorabuyer/config/WebConfig.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/config/WebConfig.java
@@ -1,16 +1,16 @@
-package com.farmdora.farmdorabuyer.config;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-@Configuration
-public class WebConfig implements WebMvcConfigurer {
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5173")
-                .allowedMethods("GET", "POST", "DELETE", "PUT")
-                .allowCredentials(true);
-    }
-}
+//package com.farmdora.farmdorabuyer.config;
+//
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.web.servlet.config.annotation.CorsRegistry;
+//import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+//
+//@Configuration
+//public class WebConfig implements WebMvcConfigurer {
+//    @Override
+//    public void addCorsMappings(CorsRegistry registry) {
+//        registry.addMapping("/**")
+//                .allowedOrigins("http://localhost:3000")
+//                .allowedMethods("GET", "POST", "DELETE", "PUT")
+//                .allowCredentials(true);
+//    }
+//}

--- a/src/main/java/com/farmdora/farmdorabuyer/like/controller/LikeController.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/like/controller/LikeController.java
@@ -4,6 +4,7 @@ import static com.farmdora.farmdorabuyer.common.response.SuccessMessage.ADD_LIKE
 
 import com.farmdora.farmdorabuyer.common.response.HttpResponse;
 import com.farmdora.farmdorabuyer.like.service.LikeService;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,9 +20,8 @@ public class LikeController {
     private final LikeService likeService;
 
     @PutMapping("/{saleId}")
-    public ResponseEntity<?> addLike(@PathVariable("saleId") Integer saleId) {
-        // TODO Security 구현완료후 수정 예정
-        Integer userId = 1;
+    public ResponseEntity<?> addLike(Principal principal, @PathVariable("saleId") Integer saleId) {
+        Integer userId = Integer.parseInt(principal.getName());
         likeService.updateLike(userId, saleId);
         return ResponseEntity.ok().body(new HttpResponse(HttpStatus.OK, ADD_LIKE_SUCCESS.getMessage(), null));
     }

--- a/src/main/java/com/farmdora/farmdorabuyer/orders/controller/OrderController.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/orders/controller/OrderController.java
@@ -8,6 +8,7 @@ import com.farmdora.farmdorabuyer.common.response.PageResponseDTO;
 import com.farmdora.farmdorabuyer.orders.dto.OrderResponseDTO;
 import com.farmdora.farmdorabuyer.orders.dto.SearchDTO;
 import com.farmdora.farmdorabuyer.orders.service.OrderService;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -28,13 +29,10 @@ public class OrderController {
     private final OrderService orderService;
 
     @GetMapping("/order")
-    public ResponseEntity<?> getOrderList(
-            @ModelAttribute SearchDTO SearchDTO,
-            @PageableDefault(size = 5)Pageable pageable) {
-        //jwt 사용시
-        // Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        // Integer userId = ((UserDetails) authentication.getPrincipal()).getUserId();
-        int userId = 1;
+    public ResponseEntity<?> getOrderList(Principal principal,
+                                          @ModelAttribute SearchDTO SearchDTO,
+                                          @PageableDefault(size = 5) Pageable pageable) {
+        Integer userId = Integer.parseInt(principal.getName());
         PageResponseDTO<OrderResponseDTO> result = orderService.getOrderList(userId, SearchDTO, pageable);
 
         return ResponseEntity.ok()

--- a/src/main/java/com/farmdora/farmdorabuyer/orders/controller/PurchaseController.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/orders/controller/PurchaseController.java
@@ -6,6 +6,7 @@ import com.farmdora.farmdorabuyer.common.response.HttpResponse;
 import com.farmdora.farmdorabuyer.orders.dto.OrderRequestDTO.OrderFromBasketDTO;
 import com.farmdora.farmdorabuyer.orders.dto.OrderRequestDTO.OrderFromOptionDTO;
 import com.farmdora.farmdorabuyer.orders.service.PurchaseService;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,16 +22,16 @@ public class PurchaseController {
     private final PurchaseService purchaseService;
 
     @PostMapping("/basket")
-    public ResponseEntity<?> order(@RequestBody OrderFromBasketDTO orderRequest) {
-        Integer userId = 1;
+    public ResponseEntity<?> order(Principal principal, @RequestBody OrderFromBasketDTO orderRequest) {
+        Integer userId = Integer.parseInt(principal.getName());
         purchaseService.orderFromBaskets(userId, orderRequest);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, CREATE_ORDER_SUCCESS.getMessage(), null));
     }
 
     @PostMapping("/option")
-    public ResponseEntity<?> order(@RequestBody OrderFromOptionDTO orderRequest) {
-        Integer userId = 1;
+    public ResponseEntity<?> order(Principal principal, @RequestBody OrderFromOptionDTO orderRequest) {
+        Integer userId = Integer.parseInt(principal.getName());
         purchaseService.orderFromOption(userId, orderRequest);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, CREATE_ORDER_SUCCESS.getMessage(), null));

--- a/src/main/java/com/farmdora/farmdorabuyer/orders/controller/RefundController.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/orders/controller/RefundController.java
@@ -3,6 +3,7 @@ package com.farmdora.farmdorabuyer.orders.controller;
 import com.farmdora.farmdorabuyer.common.response.HttpResponse;
 import com.farmdora.farmdorabuyer.orders.dto.RefundDTO.*;
 import com.farmdora.farmdorabuyer.orders.service.RefundService;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -24,11 +25,11 @@ public class RefundController {
     private final RefundService refundService;
 
     @PostMapping("/order/refund")
-    public ResponseEntity<?> createRefund(
-            RefundRequest request,
-            @RequestParam(value = "images", required = false) MultipartFile[] images) throws IOException {
+    public ResponseEntity<?> createRefund(Principal principal,
+                                          RefundRequest request,
+                                          @RequestParam(value = "images", required = false) MultipartFile[] images) throws IOException {
 
-        Integer userId = 1;
+        Integer userId = Integer.parseInt(principal.getName());
 
         List<MultipartFile> imageList = images != null ? Arrays.asList(images) : new ArrayList<>();
         RefundResponse response = refundService.createRefund(userId, request, imageList);

--- a/src/main/java/com/farmdora/farmdorabuyer/orders/controller/ReviewController.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/orders/controller/ReviewController.java
@@ -5,6 +5,7 @@ import com.farmdora.farmdorabuyer.common.response.PageResponseDTO;
 import com.farmdora.farmdorabuyer.orders.dto.ReviewDTO.*;
 import com.farmdora.farmdorabuyer.orders.dto.SearchDTO;
 import com.farmdora.farmdorabuyer.orders.service.ReviewService;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -38,10 +39,10 @@ public class ReviewController {
     }
   
     @GetMapping("/order/myreviews")
-    public ResponseEntity<?> getMyReviews(
-            @ModelAttribute SearchDTO searchDTO,
-            @PageableDefault(size = 5) Pageable pageable) {
-        Integer userId = 1;
+    public ResponseEntity<?> getMyReviews(Principal principal,
+                                          @ModelAttribute SearchDTO searchDTO,
+                                          @PageableDefault(size = 5) Pageable pageable) {
+        Integer userId = Integer.parseInt(principal.getName());
         PageResponseDTO<ReviewResponse> pageResponse = reviewService.getMyReviews(userId, searchDTO, pageable);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, "리뷰를 성공적으로 조회했습니다.", pageResponse));

--- a/src/main/java/com/farmdora/farmdorabuyer/orders/repository/BasketRepository.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/orders/repository/BasketRepository.java
@@ -1,12 +1,17 @@
 package com.farmdora.farmdorabuyer.orders.repository;
 
+import com.farmdora.farmdorabuyer.basket.dto.BasketResponseDto;
 import com.farmdora.farmdorabuyer.entity.Basket;
 import com.farmdora.farmdorabuyer.entity.Option;
 import com.farmdora.farmdorabuyer.entity.User;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BasketRepository extends JpaRepository<Basket, Integer> {
     @EntityGraph(attributePaths = {"option"})
@@ -20,4 +25,22 @@ public interface BasketRepository extends JpaRepository<Basket, Integer> {
     Optional<Basket> findByIdAndUser(Integer basketId, User user);
 
     Long countByUser(User user);
+
+    @Query("""
+        SELECT new com.farmdora.farmdorabuyer.basket.dto.BasketResponseDto(
+            b.id,
+            s.id,
+            s.title,
+            o.name,
+            b.quantity,
+            o.price,
+            sf.saveFile
+        )
+        FROM Basket b
+        JOIN b.option o
+        JOIN o.sale s
+        LEFT JOIN SaleFile sf ON sf.sale = s AND sf.isMain = true
+        WHERE b.user = :user
+    """)
+    Page<BasketResponseDto> findAllWithMainImageByUser(@Param("user") User user, Pageable pageable);
 }

--- a/src/main/java/com/farmdora/farmdorabuyer/orders/service/NCPObjectStorageService.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/orders/service/NCPObjectStorageService.java
@@ -1,13 +1,11 @@
 package com.farmdora.farmdorabuyer.orders.service;
 
-import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.*;
-import com.farmdora.farmdorabuyer.common.exception.FileException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -20,7 +18,7 @@ import java.util.UUID;
 
 @Service
 @Slf4j
-public class NCPObjectStorageService implements StorageService{
+public class NCPObjectStorageService {
 
     private final AmazonS3 s3;
     private final String bucketName;
@@ -53,7 +51,7 @@ public class NCPObjectStorageService implements StorageService{
 
     }
 
-    @Override
+//    @Override
     public void upload(String filePath, InputStream fileIn) {
 
         ObjectMetadata objectMetadata = new ObjectMetadata();
@@ -74,7 +72,7 @@ public class NCPObjectStorageService implements StorageService{
         }
     }
 
-    @Override
+//    @Override
     public void download(String filePath, OutputStream fileOut) {
         try {
             S3Object s3Object = s3.getObject(bucketName, filePath);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 8020
+
 spring:
   profiles:
     active: local
@@ -5,6 +8,14 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+
+  jwt:
+    secret: ENC(AJv6LokZXWCLSDdDEFT1UGe19935JohjmPnbyDPFNQWa+WgVgEaBrsg3Fo8Xo8Myj3KHBd5e5Ka5pLS8nyOm2NNBdvwSAbjfBlpcZENOkyA=)
+
+jasypt:
+  encryptor:
+    password: ${key}
+    bean: jasyptEncryptor
 
 ncp:
   object-storage:
@@ -16,5 +27,9 @@ ncp:
     project-id: O8XfcLSSm6
     cdn-domain: zcbg41sa9729.edge.naverncp.com
 
-  access-key: ENC(h5+OKxEsP1RHEaoQJABFNTMXE9amleET4Vhprr7SCAUckb+euFrFEQ==)
-  secret-key: ENC(l9Q/rUdMAA7i3iTgzZpclwNjx+ysbs5WPTZst6XNbg+BvKuzPzwpM8LZjVfaqr+1by24jGXYSBc=)
+  image:
+    path: https://zcbg41sa9729.edge.naverncp.com/O8XfcLSSm6/product/
+    type: ?type=h&h=192&ttype=png
+
+  access-key: ENC(oBvxn6C62QrqLs0N+lCb/UgxymXI4OALon5g0YLglZPwPFQnm6C8tw==)
+  secret-key: ENC(DF529oTSIv/sQj/hDvwfK/wWVcpf2Yrq77NrKNeZws72YdMkTsI0ziMOZr4cCFgda/jcqcaPkDM=)

--- a/src/test/java/com/farmdora/farmdorabuyer/ControllerTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/ControllerTest.java
@@ -1,0 +1,42 @@
+package com.farmdora.farmdorabuyer;
+
+import com.farmdora.farmdorabuyer.basket.controller.BasketController;
+import com.farmdora.farmdorabuyer.basket.service.BasketService;
+import com.farmdora.farmdorabuyer.like.controller.LikeController;
+import com.farmdora.farmdorabuyer.like.service.LikeService;
+import com.farmdora.farmdorabuyer.orders.controller.PurchaseController;
+import com.farmdora.farmdorabuyer.orders.service.PurchaseService;
+import com.farmdora.farmdorabuyer.security.TestSecurityConfig;
+import com.farmdora.farmdorabuyer.security.WithCustomMockUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = {
+    BasketController.class,
+    LikeController.class,
+    PurchaseController.class
+})
+@WithCustomMockUser
+@Import({TestSecurityConfig.class})
+public abstract class ControllerTest {
+
+    @Autowired
+    protected MockMvc mvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @MockitoBean
+    protected BasketService basketService;
+
+    @MockitoBean
+    protected LikeService likeService;
+
+    @MockitoBean
+    protected PurchaseService purchaseService;
+
+}

--- a/src/test/java/com/farmdora/farmdorabuyer/basket/controller/BasketControllerTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/basket/controller/BasketControllerTest.java
@@ -7,6 +7,7 @@ import static com.farmdora.farmdorabuyer.common.response.SuccessMessage.UPDATE_B
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
@@ -19,36 +20,24 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.farmdora.farmdorabuyer.ControllerTest;
 import com.farmdora.farmdorabuyer.basket.dto.BasketRequestDto;
 import com.farmdora.farmdorabuyer.basket.dto.BasketResponseDto;
-import com.farmdora.farmdorabuyer.basket.exception.QuantityOverLimitException;
 import com.farmdora.farmdorabuyer.basket.exception.BasketOverLimitException;
-import com.farmdora.farmdorabuyer.basket.service.BasketService;
+import com.farmdora.farmdorabuyer.basket.exception.QuantityOverLimitException;
 import com.farmdora.farmdorabuyer.common.exception.ResourceAlreadyExistsException;
 import com.farmdora.farmdorabuyer.common.exception.ResourceNotFoundException;
+import com.farmdora.farmdorabuyer.common.response.PageResponseDTO;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(controllers = BasketController.class)
-class BasketControllerTest {
-
-    @MockitoBean
-    private BasketService basketService;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @Autowired
-    private MockMvc mvc;
+class BasketControllerTest extends ControllerTest {
 
     @Nested
     @DisplayName("장바구니 추가 API 테스트")
@@ -166,7 +155,10 @@ class BasketControllerTest {
                             .price(2000)
                             .build()
             );
-            when(basketService.getBaskets(anyInt())).thenReturn(baskets);
+            PageResponseDTO<BasketResponseDto> pageResponse = new PageResponseDTO<>();
+            pageResponse.setContents(baskets);
+            pageResponse.setTotalElements(2);
+            when(basketService.getBaskets(anyInt(), any(Pageable.class))).thenReturn(pageResponse);
 
             // when
             // then
@@ -174,7 +166,7 @@ class BasketControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.status", equalTo(200)))
                     .andExpect(jsonPath("$.message", equalTo(GET_BASKETS_SUCCESS.getMessage())))
-                    .andExpect(jsonPath("$.data.size()", equalTo(2)));
+                    .andExpect(jsonPath("$.data.contents.size()", equalTo(2)));
         }
     }
 
@@ -182,15 +174,19 @@ class BasketControllerTest {
     @DisplayName("사용자의 장바구니 삭제 API 테스트")
     class RemoveBasketsTest {
 
+        private static final List<Integer> basketIds = List.of(1, 2, 3, 4);
+
         @Test
         @DisplayName("사용자의 장바구니 삭제 성공")
         void testRemoveBasket() throws Exception {
             // given
-            doNothing().when(basketService).removeBasket(anyInt(), anyInt());
+            doNothing().when(basketService).removeBaskets(anyInt(), anyList());
 
             // when
             // then
-            mvc.perform(delete("/api/basket/{basketId}", 1))
+            mvc.perform(delete("/api/basket")
+                            .content(objectMapper.writeValueAsString(basketIds))
+                            .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.status", equalTo(200)))
                     .andExpect(jsonPath("$.message", equalTo(REMOVE_BASKET_SUCCESS.getMessage())));
@@ -200,11 +196,13 @@ class BasketControllerTest {
         @DisplayName("사용자의 장바구니 삭제시 장바구니가 없을 경우 에러처리 테스트")
         void testRemoveBasket_ResourceNotFoundException() throws Exception {
             // given
-            doThrow(new ResourceNotFoundException("Basket", 1)).when(basketService).removeBasket(anyInt(), anyInt());
+            doThrow(new ResourceNotFoundException("Basket", 1)).when(basketService).removeBaskets(anyInt(), anyList());
 
             // when
             // then
-            mvc.perform(delete("/api/basket/{basketId}", 1))
+            mvc.perform(delete("/api/basket")
+                            .content(objectMapper.writeValueAsString(basketIds))
+                            .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.status", equalTo(400)))
                     .andExpect(jsonPath("$.message", equalTo("Basket 데이터가 존재하지 않습니다 : '1'")));

--- a/src/test/java/com/farmdora/farmdorabuyer/basket/service/BasketServiceTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/basket/service/BasketServiceTest.java
@@ -14,9 +14,9 @@ import com.farmdora.farmdorabuyer.basket.exception.QuantityOverLimitException;
 import com.farmdora.farmdorabuyer.basket.exception.BasketOverLimitException;
 import com.farmdora.farmdorabuyer.common.exception.ResourceAlreadyExistsException;
 import com.farmdora.farmdorabuyer.common.exception.ResourceNotFoundException;
+import com.farmdora.farmdorabuyer.common.response.PageResponseDTO;
 import com.farmdora.farmdorabuyer.entity.Basket;
 import com.farmdora.farmdorabuyer.entity.Option;
-import com.farmdora.farmdorabuyer.entity.Sale;
 import com.farmdora.farmdorabuyer.entity.User;
 import com.farmdora.farmdorabuyer.orders.repository.BasketRepository;
 import com.farmdora.farmdorabuyer.orders.repository.OptionRepository;
@@ -24,11 +24,16 @@ import com.farmdora.farmdorabuyer.orders.repository.UserRepository;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 class BasketServiceTest {
@@ -45,257 +50,276 @@ class BasketServiceTest {
     @InjectMocks
     private BasketService basketService;
 
-    @Test
+    @Nested
     @DisplayName("장바구니 추가 서비스 레이어 테스트")
-    void testAddBasket() {
-        // given
-        User mockUser = User.builder()
-                .userId(1)
-                .build();
-        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+    class AddBasketTests {
 
-        Option mockOption = Option.builder()
-                .name("옵션")
-                .quantity(20)
-                .build();
-        when(optionRepository.findById(anyInt())).thenReturn(Optional.of(mockOption));
+        @Test
+        @DisplayName("장바구니 추가 서비스 레이어 테스트")
+        void testAddBasket() {
+            // given
+            User mockUser = User.builder()
+                    .userId(1)
+                    .build();
+            when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
 
-        // when
-        BasketRequestDto basketAddRequest = BasketRequestDto.builder()
-                .optionId(1)
-                .quantity(10)
-                .build();
-        basketService.addBasket(1, basketAddRequest);
+            Option mockOption = Option.builder()
+                    .name("옵션")
+                    .quantity(20)
+                    .build();
+            when(optionRepository.findById(anyInt())).thenReturn(Optional.of(mockOption));
 
-        // then
-        verify(basketRepository, times(1)).save(any(Basket.class));
+            // when
+            BasketRequestDto basketAddRequest = BasketRequestDto.builder()
+                    .optionId(1)
+                    .quantity(10)
+                    .build();
+            basketService.addBasket(1, basketAddRequest);
+
+            // then
+            verify(basketRepository, times(1)).save(any(Basket.class));
+        }
+
+        @Test
+        @DisplayName("장바구니 추가시 존재하지 않는 옵션일 경우 예외 발생")
+        void testAddBasket_OptionNotFoundException() {
+            // given
+            User mockUser = User.builder()
+                    .userId(1)
+                    .build();
+            when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+            when(optionRepository.findById(anyInt())).thenReturn(Optional.empty());
+
+            // when
+            // then
+            BasketRequestDto basketAddRequest = BasketRequestDto.builder()
+                    .optionId(1)
+                    .quantity(10)
+                    .build();
+            assertThatThrownBy(() -> basketService.addBasket(1, basketAddRequest))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("장바구니 추가시 존재하지 않는 옵션일 경우 예외 발생")
+        void testAddBasket_QuantityOverLimitException() {
+            // given
+            User mockUser = User.builder()
+                    .userId(1)
+                    .build();
+            when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+
+            Option mockOption = Option.builder()
+                    .name("옵션")
+                    .quantity(1)
+                    .build();
+            when(optionRepository.findById(anyInt())).thenReturn(Optional.of(mockOption));
+
+            // when
+            // then
+            BasketRequestDto basketAddRequest = BasketRequestDto.builder()
+                    .optionId(1)
+                    .quantity(10)
+                    .build();
+            assertThatThrownBy(() -> basketService.addBasket(1, basketAddRequest))
+                    .isInstanceOf(QuantityOverLimitException.class);
+        }
+
+        @Test
+        @DisplayName("장바구니 추가시 이미 존재할 경우 예외 발생")
+        void testAddBasket_BasketAlreadyExistsException() {
+            // given
+            User mockUser = User.builder()
+                    .userId(1)
+                    .build();
+            when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+
+            Option mockOption = Option.builder()
+                    .name("옵션")
+                    .quantity(20)
+                    .build();
+            when(optionRepository.findById(anyInt())).thenReturn(Optional.of(mockOption));
+
+            Basket mockBasket = Basket.builder()
+                    .user(mockUser)
+                    .option(mockOption)
+                    .build();
+            when(basketRepository.findByUserAndOption(any(User.class), any(Option.class))).thenReturn(Optional.of(mockBasket));
+
+            // when
+            // then
+            BasketRequestDto basketAddRequest = BasketRequestDto.builder()
+                    .optionId(1)
+                    .quantity(10)
+                    .build();
+            assertThatThrownBy(() -> basketService.addBasket(1, basketAddRequest))
+                    .isInstanceOf(ResourceAlreadyExistsException.class);
+        }
+
+        @Test
+        @DisplayName("장바구니 추가시 장바구니 목록이 이미 16개일 경우 예외 발생")
+        void testAddBasket_BasketOverLimitException() {
+            // given
+            User mockUser = User.builder()
+                    .userId(1)
+                    .build();
+            when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+
+            Option mockOption = Option.builder()
+                    .id(1)
+                    .quantity(20)
+                    .name("옵션")
+                    .build();
+            when(optionRepository.findById(anyInt())).thenReturn(Optional.of(mockOption));
+
+            when(basketRepository.findByUserAndOption(any(User.class), any(Option.class))).thenReturn(Optional.empty());
+            when(basketRepository.countByUser(any(User.class))).thenReturn(16L);
+
+            // when
+            // then
+            BasketRequestDto basketAddRequest = BasketRequestDto.builder()
+                    .optionId(1)
+                    .quantity(10)
+                    .build();
+            assertThatThrownBy(() -> basketService.addBasket(1, basketAddRequest))
+                    .isInstanceOf(BasketOverLimitException.class);
+        }
     }
 
-    @Test
-    @DisplayName("장바구니 추가시 존재하지 않는 옵션일 경우 예외 발생")
-    void testAddBasket_OptionNotFoundException() {
-        // given
-        User mockUser = User.builder()
-                .userId(1)
-                .build();
-        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
-        when(optionRepository.findById(anyInt())).thenReturn(Optional.empty());
+    @Nested
+    @DisplayName("장바구니 목록 조회 서비스 레이어 테스트")
+    class GetBasketsTests {
 
-        // when
-        // then
-        BasketRequestDto basketAddRequest = BasketRequestDto.builder()
-                .optionId(1)
-                .quantity(10)
-                .build();
-        assertThatThrownBy(() -> basketService.addBasket(1, basketAddRequest))
-                .isInstanceOf(ResourceNotFoundException.class);
+        @Test
+        @DisplayName("사용자의 장바구니 목록 조회 성공")
+        void testGetBaskets() {
+            // given
+            User mockUser = User.builder()
+                    .userId(1)
+                    .build();
+            when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+
+            List<BasketResponseDto> baskets = List.of(
+                    BasketResponseDto.builder()
+                            .basketId(1)
+                            .saleId(1)
+                            .title("title1")
+                            .option("option1")
+                            .quantity(10)
+                            .price(10000)
+                            .imageUrl("imageUrl1")
+                            .build(),
+                    BasketResponseDto.builder()
+                            .basketId(2)
+                            .saleId(2)
+                            .title("title2")
+                            .option("option2")
+                            .quantity(20)
+                            .price(20000)
+                            .imageUrl("imageUrl2")
+                            .build()
+            );
+            Pageable pageable = PageRequest.of(0, 5);
+            Page<BasketResponseDto> basketPage = new PageImpl<>(baskets, pageable, 2);
+            when(basketRepository.findAllWithMainImageByUser(any(User.class), any(Pageable.class))).thenReturn(basketPage);
+
+            // when
+            PageResponseDTO<BasketResponseDto> result = basketService.getBaskets(1, PageRequest.of(0, 10));
+
+            // then
+            BasketResponseDto basket1 = result.getContents().get(0);
+            assertThat(result.getTotalElements()).isEqualTo(2);
+            assertThat(basket1.getTitle()).isEqualTo("title1");
+            assertThat(basket1.getQuantity()).isEqualTo(10);
+        }
     }
 
-    @Test
-    @DisplayName("장바구니 추가시 존재하지 않는 옵션일 경우 예외 발생")
-    void testAddBasket_QuantityOverLimitException() {
-        // given
-        User mockUser = User.builder()
-                .userId(1)
-                .build();
-        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+    @Nested
+    @DisplayName("장바구니 삭제 서비스 레이어 테스트")
+    class RemoveBasketTests {
 
-        Option mockOption = Option.builder()
-                .name("옵션")
-                .quantity(1)
-                .build();
-        when(optionRepository.findById(anyInt())).thenReturn(Optional.of(mockOption));
+        @Test
+        @DisplayName("사용자의 특정 장바구니 삭제 성공")
+        void testRemoveBasket() {
+            // given
+            User mockUser = User.builder()
+                    .userId(1)
+                    .build();
+            when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
 
-        // when
-        // then
-        BasketRequestDto basketAddRequest = BasketRequestDto.builder()
-                .optionId(1)
-                .quantity(10)
-                .build();
-        assertThatThrownBy(() -> basketService.addBasket(1, basketAddRequest))
-                .isInstanceOf(QuantityOverLimitException.class);
+            Basket mockBasket = Basket.builder()
+                    .id(1)
+                    .user(mockUser)
+                    .build();
+            when(basketRepository.findByIdAndUser(anyInt(), any(User.class))).thenReturn(Optional.of(mockBasket));
+
+            // when
+            basketService.removeBasket(1, 1);
+
+            // then
+            verify(basketRepository, times(1)).delete(any(Basket.class));
+        }
+
+        @Test
+        @DisplayName("사용자의 특정 장바구니 삭제시 장바구니가 존재하지 않을 경우 예외 발생 테스트")
+        void testRemoveBasket_ResourceNotFoundException() {
+            // given
+            User mockUser = User.builder()
+                    .userId(1)
+                    .build();
+            when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+
+            when(basketRepository.findByIdAndUser(anyInt(), any(User.class))).thenReturn(Optional.empty());
+
+            // when
+            // then
+            assertThatThrownBy(() -> basketService.removeBasket(1, 1))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
     }
 
-    @Test
-    @DisplayName("장바구니 추가시 이미 존재할 경우 예외 발생")
-    void testAddBasket_BasketAlreadyExistsException() {
-        // given
-        User mockUser = User.builder()
-                .userId(1)
-                .build();
-        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+    @Nested
+    @DisplayName("장바구니 추가 서비스 레이어 테스트")
+    class UpdateBasketTests {
 
-        Option mockOption = Option.builder()
-                .name("옵션")
-                .quantity(20)
-                .build();
-        when(optionRepository.findById(anyInt())).thenReturn(Optional.of(mockOption));
+        @Test
+        @DisplayName("사용자의 장바구니 수량 수정 성공")
+        void testUpdateBasketQuantity() {
+            // given
+            User mockUser = User.builder()
+                    .userId(1)
+                    .build();
+            when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
 
-        Basket mockBasket = Basket.builder()
-                .user(mockUser)
-                .option(mockOption)
-                .build();
-        when(basketRepository.findByUserAndOption(any(User.class), any(Option.class))).thenReturn(Optional.of(mockBasket));
+            Basket mockBasket = Basket.builder()
+                    .id(1)
+                    .user(mockUser)
+                    .quantity(1)
+                    .build();
+            when(basketRepository.findByIdAndUser(anyInt(), any(User.class))).thenReturn(Optional.of(mockBasket));
 
-        // when
-        // then
-        BasketRequestDto basketAddRequest = BasketRequestDto.builder()
-                .optionId(1)
-                .quantity(10)
-                .build();
-        assertThatThrownBy(() -> basketService.addBasket(1, basketAddRequest))
-                .isInstanceOf(ResourceAlreadyExistsException.class);
-    }
+            // when
+            basketService.updateBasketQuantity(1, 1, 10);
 
-    @Test
-    @DisplayName("장바구니 추가시 장바구니 목록이 이미 16개일 경우 예외 발생")
-    void testAddBasket_BasketOverLimitException() {
-        // given
-        User mockUser = User.builder()
-                .userId(1)
-                .build();
-        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
+            // then
+            assertThat(mockBasket.getQuantity()).isEqualTo(10);
+        }
 
-        Option mockOption = Option.builder()
-                .id(1)
-                .quantity(20)
-                .name("옵션")
-                .build();
-        when(optionRepository.findById(anyInt())).thenReturn(Optional.of(mockOption));
+        @Test
+        @DisplayName("사용자의 장바구니 수량 수정시 장바구니가 존재하지 않을 경우 예외 발생 테스트")
+        void testUpdateBasketQuantity_ResourceNotFoundException() {
+            // given
+            User mockUser = User.builder()
+                    .userId(1)
+                    .build();
+            when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
 
-        when(basketRepository.findByUserAndOption(any(User.class), any(Option.class))).thenReturn(Optional.empty());
-        when(basketRepository.countByUser(any(User.class))).thenReturn(16L);
+            when(basketRepository.findByIdAndUser(anyInt(), any(User.class))).thenReturn(Optional.empty());
 
-        // when
-        // then
-        BasketRequestDto basketAddRequest = BasketRequestDto.builder()
-                .optionId(1)
-                .quantity(10)
-                .build();
-        assertThatThrownBy(() -> basketService.addBasket(1, basketAddRequest))
-                .isInstanceOf(BasketOverLimitException.class);
-    }
-
-    @Test
-    @DisplayName("사용자의 장바구니 목록 조회")
-    void testGetBaskets() {
-        // given
-        User mockUser = User.builder()
-                .userId(1)
-                .build();
-        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
-
-        Sale mockSale = Sale.builder()
-                .id(1)
-                .title("상품")
-                .build();
-
-        Option mockOption = Option.builder()
-                .id(1)
-                .sale(mockSale)
-                .name("옵션")
-                .build();
-
-        List<Basket> baskets = List.of(
-                Basket.builder()
-                        .user(mockUser)
-                        .quantity(2)
-                        .option(mockOption)
-                        .build(),
-                Basket.builder()
-                        .user(mockUser)
-                        .quantity(10)
-                        .option(mockOption)
-                        .build()
-        );
-        when(basketRepository.findAllByUser(any(User.class))).thenReturn(baskets);
-
-        // when
-        List<BasketResponseDto> result = basketService.getBaskets(1);
-
-        // then
-        BasketResponseDto basket1 = result.get(0);
-        assertThat(result.size()).isEqualTo(2);
-        assertThat(basket1.getTitle()).isEqualTo("상품");
-        assertThat(basket1.getQuantity()).isEqualTo(2);
-    }
-
-    @Test
-    @DisplayName("사용자의 특정 장바구니 삭제 서비스 레이어 테스트")
-    void testRemoveBasket() {
-        // given
-        User mockUser = User.builder()
-                .userId(1)
-                .build();
-        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
-
-        Basket mockBasket = Basket.builder()
-                .id(1)
-                .user(mockUser)
-                .build();
-        when(basketRepository.findByIdAndUser(anyInt(), any(User.class))).thenReturn(Optional.of(mockBasket));
-
-        // when
-        basketService.removeBasket(1, 1);
-
-        // then
-        verify(basketRepository, times(1)).delete(any(Basket.class));
-    }
-
-    @Test
-    @DisplayName("사용자의 특정 장바구니 삭제시 장바구니가 존재하지 않을 경우 예외 발생 테스트")
-    void testRemoveBasket_ResourceNotFoundException() {
-        // given
-        User mockUser = User.builder()
-                .userId(1)
-                .build();
-        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
-
-        when(basketRepository.findByIdAndUser(anyInt(), any(User.class))).thenReturn(Optional.empty());
-
-        // when
-        // then
-        assertThatThrownBy(() -> basketService.removeBasket(1, 1))
-                .isInstanceOf(ResourceNotFoundException.class);
-    }
-
-    @Test
-    @DisplayName("사용자의 장바구니 수량 수정 서비스 레이어 테스트")
-    void testUpdateBasketQuantity() {
-        // given
-        User mockUser = User.builder()
-                .userId(1)
-                .build();
-        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
-
-        Basket mockBasket = Basket.builder()
-                .id(1)
-                .user(mockUser)
-                .quantity(1)
-                .build();
-        when(basketRepository.findByIdAndUser(anyInt(), any(User.class))).thenReturn(Optional.of(mockBasket));
-
-        // when
-        basketService.updateBasketQuantity(1, 1, 10);
-
-        // then
-        assertThat(mockBasket.getQuantity()).isEqualTo(10);
-    }
-
-    @Test
-    @DisplayName("사용자의 장바구니 수량 수정시 장바구니가 존재하지 않을 경우 예외 발생 테스트")
-    void testUpdateBasketQuantity_ResourceNotFoundException() {
-        // given
-        User mockUser = User.builder()
-                .userId(1)
-                .build();
-        when(userRepository.findById(anyInt())).thenReturn(Optional.of(mockUser));
-
-        when(basketRepository.findByIdAndUser(anyInt(), any(User.class))).thenReturn(Optional.empty());
-
-        // when
-        // then
-        assertThatThrownBy(() -> basketService.updateBasketQuantity(1, 1, 10))
-                .isInstanceOf(ResourceNotFoundException.class);
+            // when
+            // then
+            assertThatThrownBy(() -> basketService.updateBasketQuantity(1, 1, 10))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
     }
 }

--- a/src/test/java/com/farmdora/farmdorabuyer/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/like/controller/LikeControllerTest.java
@@ -10,22 +10,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.farmdora.farmdorabuyer.like.service.LikeService;
+import com.farmdora.farmdorabuyer.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(LikeController.class)
-class LikeControllerTest {
-
-    @MockitoBean
-    private LikeService likeService;
-
-    @Autowired
-    private MockMvc mvc;
+class LikeControllerTest extends ControllerTest {
 
     @Test
     @DisplayName("찜 추가/삭제 API 테스트")

--- a/src/test/java/com/farmdora/farmdorabuyer/orders/controller/PurchaseControllerTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/orders/controller/PurchaseControllerTest.java
@@ -44,7 +44,7 @@ class PurchaseControllerTest extends ControllerTest {
             // then
             mvc.perform(post(URL)
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(new ObjectMapper().writeValueAsString(orderRequest)))
+                            .content(objectMapper.writeValueAsString(orderRequest)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.status", equalTo(200)))
                     .andExpect(jsonPath("$.message", equalTo(CREATE_ORDER_SUCCESS.getMessage())));
@@ -60,7 +60,7 @@ class PurchaseControllerTest extends ControllerTest {
             // then
             mvc.perform(post(URL)
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(new ObjectMapper().writeValueAsString(orderRequest)))
+                            .content(objectMapper.writeValueAsString(orderRequest)))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.status", equalTo(400)))
                     .andExpect(jsonPath("$.message", equalTo("User 데이터가 존재하지 않습니다 : '1'")));
@@ -76,7 +76,7 @@ class PurchaseControllerTest extends ControllerTest {
             // then
             mvc.perform(post(URL)
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(new ObjectMapper().writeValueAsString(orderRequest)))
+                            .content(objectMapper.writeValueAsString(orderRequest)))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.status", equalTo(400)))
                     .andExpect(jsonPath("$.message", equalTo("Depot 데이터가 존재하지 않습니다 : '1'")));
@@ -92,7 +92,7 @@ class PurchaseControllerTest extends ControllerTest {
             // then
             mvc.perform(post(URL)
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(new ObjectMapper().writeValueAsString(orderRequest)))
+                            .content(objectMapper.writeValueAsString(orderRequest)))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.status", equalTo(400)))
                     .andExpect(jsonPath("$.message", equalTo("사용자의 배송지가 아닙니다.")));
@@ -108,7 +108,7 @@ class PurchaseControllerTest extends ControllerTest {
             // then
             mvc.perform(post(URL)
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(new ObjectMapper().writeValueAsString(orderRequest)))
+                            .content(objectMapper.writeValueAsString(orderRequest)))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.status", equalTo(400)))
                     .andExpect(jsonPath("$.message", equalTo("OrderStatus 데이터가 존재하지 않습니다 : '1'")));
@@ -124,7 +124,7 @@ class PurchaseControllerTest extends ControllerTest {
             // then
             mvc.perform(post(URL)
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(new ObjectMapper().writeValueAsString(orderRequest)))
+                            .content(objectMapper.writeValueAsString(orderRequest)))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.status", equalTo(400)))
                     .andExpect(jsonPath("$.message", equalTo("재고가 없습니다.")));

--- a/src/test/java/com/farmdora/farmdorabuyer/orders/controller/PurchaseControllerTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/orders/controller/PurchaseControllerTest.java
@@ -10,30 +10,18 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.farmdora.farmdorabuyer.ControllerTest;
 import com.farmdora.farmdorabuyer.common.exception.ResourceNotFoundException;
 import com.farmdora.farmdorabuyer.orders.dto.OrderRequestDTO.OrderFromBasketDTO;
 import com.farmdora.farmdorabuyer.orders.exception.NotUserOfDepotException;
 import com.farmdora.farmdorabuyer.orders.exception.OutOfStockException;
-import com.farmdora.farmdorabuyer.orders.service.PurchaseService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(controllers = PurchaseController.class)
-class PurchaseControllerTest {
-
-    @MockitoBean
-    private PurchaseService purchaseService;
-
-    @Autowired
-    private MockMvc mvc;
+class PurchaseControllerTest extends ControllerTest {
 
     @Nested
     @DisplayName("장바구니 목록으로 주문 API 테스트")

--- a/src/test/java/com/farmdora/farmdorabuyer/orders/service/PurchaseServiceTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/orders/service/PurchaseServiceTest.java
@@ -430,6 +430,13 @@ class PurchaseServiceTest {
                     .build();
             when(orderStatusRepository.findByName(anyString())).thenReturn(Optional.of(mockOrderStatus));
 
+            Option mockOption = Option.builder()
+                    .id(1)
+                    .price(10000)
+                    .quantity(10)
+                    .build();
+            when(optionRepository.findById(anyInt())).thenReturn(Optional.of(mockOption));
+
             // when
             // then
             OrderFromOptionDTO orderRequest = OrderFromOptionDTO.builder()

--- a/src/test/java/com/farmdora/farmdorabuyer/security/TestSecurityConfig.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/security/TestSecurityConfig.java
@@ -1,0 +1,18 @@
+package com.farmdora.farmdorabuyer.security;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http.csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorizeRequests -> authorizeRequests.anyRequest().permitAll())
+                .build();
+    }
+}

--- a/src/test/java/com/farmdora/farmdorabuyer/security/WithCustomMockUser.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/security/WithCustomMockUser.java
@@ -1,0 +1,12 @@
+package com.farmdora.farmdorabuyer.security;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithCustomMockUserSecurityContextFactory.class)
+public @interface WithCustomMockUser {
+    String username() default "1";
+    String role() default "USER";
+}

--- a/src/test/java/com/farmdora/farmdorabuyer/security/WithCustomMockUserSecurityContextFactory.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/security/WithCustomMockUserSecurityContextFactory.java
@@ -1,0 +1,23 @@
+package com.farmdora.farmdorabuyer.security;
+
+import java.util.List;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithCustomMockUserSecurityContextFactory implements WithSecurityContextFactory<WithCustomMockUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithCustomMockUser annotation) {
+        String username = annotation.username();
+        String role = annotation.role();
+
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(username, "password", List.of(new SimpleGrantedAuthority(role)));
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(token);
+        return context;
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,15 +5,32 @@ spring:
     username: sa
     password:
 
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379
+
+  jwt:
+    secret: ENC(AJv6LokZXWCLSDdDEFT1UGe19935JohjmPnbyDPFNQWa+WgVgEaBrsg3Fo8Xo8Myj3KHBd5e5Ka5pLS8nyOm2NNBdvwSAbjfBlpcZENOkyA=)
+
+jasypt:
+  encryptor:
+    password: ${key}
+    bean: jasyptEncryptor
+
 ncp:
   object-storage:
     endpoint: https://kr.object.ncloudstorage.com
     region: kr-standard
-    bucket: farmdora
+    bucket: bitcamp-68
 
   image-optimizer:
-    project-id: Gv9VppsiR9
-    cdn-domain: aacblnby9780.edge.naverncp.com
+    project-id: O8XfcLSSm6
+    cdn-domain: zcbg41sa9729.edge.naverncp.com
 
-  access-key: ncp_iam_BPASKR5nKujGrW7C2yV5
-  secret-key: ncp_iam_BPKSKRPXwNzYCHv9zMJfroeR2XA8e47gQv
+  image:
+    path: https://zcbg41sa9729.edge.naverncp.com/O8XfcLSSm6/product/
+    type: ?type=h&h=192&ttype=png
+
+  access-key: ENC(oBvxn6C62QrqLs0N+lCb/UgxymXI4OALon5g0YLglZPwPFQnm6C8tw==)
+  secret-key: ENC(DF529oTSIv/sQj/hDvwfK/wWVcpf2Yrq77NrKNeZws72YdMkTsI0ziMOZr4cCFgda/jcqcaPkDM=)


### PR DESCRIPTION
## 📌 작업 내용
- [x] Spring Security 적용
- [x] JWT 토큰 검증 필터 적용
- [x] 장바구니 목록 조회 로직 수정
- [x] 장바구니 삭제 로직 수정
- [x] 테스트 케이스 수정
- [x] Jasypt 설정 클래스 추가
- [x] Redis 설정 클래스 추가
- [x] 모드 컨트롤러에 `Principal` 적용

<br>

## 💡 필수확인
- 장바구니 목록 조회 시 페이지네이션 적용
- 장바구니 삭제시 여러개의 id값을 전달받도록 수정

<br>

## 📆 작업기간
2025.05.04