### PR TITLE
[FDORA-162] fix: 테스트 코드 및 설정 수정

### DIFF
--- a/src/main/java/com/farmdora/farmdorabuyer/basket/dto/BasketResponseDto.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/basket/dto/BasketResponseDto.java
@@ -18,6 +18,7 @@ public class BasketResponseDto {
     private Integer saleId;
     private String title;
     private String option;
+    private Integer stock;
     private Integer quantity;
     private Integer price;
     private String imageUrl;

--- a/src/main/java/com/farmdora/farmdorabuyer/orders/repository/BasketRepository.java
+++ b/src/main/java/com/farmdora/farmdorabuyer/orders/repository/BasketRepository.java
@@ -32,6 +32,7 @@ public interface BasketRepository extends JpaRepository<Basket, Integer> {
             s.id,
             s.title,
             o.name,
+            o.quantity,
             b.quantity,
             o.price,
             sf.saveFile

--- a/src/test/java/com/farmdora/farmdorabuyer/ControllerTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/ControllerTest.java
@@ -6,6 +6,8 @@ import com.farmdora.farmdorabuyer.like.controller.LikeController;
 import com.farmdora.farmdorabuyer.like.service.LikeService;
 import com.farmdora.farmdorabuyer.orders.controller.PurchaseController;
 import com.farmdora.farmdorabuyer.orders.service.PurchaseService;
+import com.farmdora.farmdorabuyer.popup.controller.PopupController;
+import com.farmdora.farmdorabuyer.popup.service.PopupService;
 import com.farmdora.farmdorabuyer.security.TestSecurityConfig;
 import com.farmdora.farmdorabuyer.security.WithCustomMockUser;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -18,7 +20,8 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(controllers = {
     BasketController.class,
     LikeController.class,
-    PurchaseController.class
+    PurchaseController.class,
+    PopupController.class
 })
 @WithCustomMockUser
 @Import({TestSecurityConfig.class})
@@ -38,5 +41,8 @@ public abstract class ControllerTest {
 
     @MockitoBean
     protected PurchaseService purchaseService;
+
+    @MockitoBean
+    protected PopupService popupService;
 
 }

--- a/src/test/java/com/farmdora/farmdorabuyer/popup/controller/PopupControllerTest.java
+++ b/src/test/java/com/farmdora/farmdorabuyer/popup/controller/PopupControllerTest.java
@@ -6,25 +6,14 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.farmdora.farmdorabuyer.ControllerTest;
 import com.farmdora.farmdorabuyer.common.response.SuccessMessage;
 import com.farmdora.farmdorabuyer.popup.dto.PopupDTO;
-import com.farmdora.farmdorabuyer.popup.service.PopupService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(controllers = PopupController.class)
-class PopupControllerTest {
-
-    @MockitoBean
-    private PopupService popupService;
-
-    @Autowired
-    private MockMvc mvc;
+class PopupControllerTest extends ControllerTest {
 
     @Test
     @DisplayName("팝업 목록 조회 ")

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -32,9 +32,5 @@ ncp:
     project-id: O8XfcLSSm6
     cdn-domain: zcbg41sa9729.edge.naverncp.com
 
-  image:
-    path: https://zcbg41sa9729.edge.naverncp.com/O8XfcLSSm6/product/
-    type: ?type=h&h=192&ttype=png
-
   access-key: ENC(oBvxn6C62QrqLs0N+lCb/UgxymXI4OALon5g0YLglZPwPFQnm6C8tw==)
   secret-key: ENC(DF529oTSIv/sQj/hDvwfK/wWVcpf2Yrq77NrKNeZws72YdMkTsI0ziMOZr4cCFgda/jcqcaPkDM=)


### PR DESCRIPTION
## 📌 작업 내용
- [x] 테스트 설정 파일 중복 내용 제거(ncp)
- [x] PopupControllerTest 수정(ControllerTest.class 상속)
- [x] 장바구니 목록 조회시 옵션의 재고수도 함께 조회

<br>

## 💡 필수확인

<br>

## 📆 작업기간
2025.05.06

<br>